### PR TITLE
fix: asset deletion not updating UI

### DIFF
--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { revalidatePath } from 'next/cache'
+
 import {
   AssetFormSchema,
   CheckoutFormSchema,
@@ -141,6 +143,7 @@ export async function deleteAsset(id: string): Promise<{ error: string } | null>
     action: 'deleted',
   })
 
+  revalidatePath('/assets')
   return null
 }
 

--- a/src/components/assets/AssetCard.tsx
+++ b/src/components/assets/AssetCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useQueryClient } from '@tanstack/react-query'
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
@@ -28,6 +29,7 @@ interface AssetCardProps {
 export function AssetCard({ asset }: AssetCardProps) {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const { user } = useAuth()
+  const queryClient = useQueryClient()
   const canEditAssets = user ? canEdit(user.role) : false
 
   return (
@@ -103,8 +105,9 @@ export function AssetCard({ asset }: AssetCardProps) {
         description="This will permanently remove the asset. This action cannot be undone."
         confirmLabel="Delete"
         destructive
-        onConfirm={() => {
-          deleteAsset(asset.id)
+        onConfirm={async () => {
+          await deleteAsset(asset.id)
+          queryClient.invalidateQueries({ queryKey: ['assets'] })
           setConfirmDelete(false)
         }}
       />

--- a/src/components/assets/AssetTable.tsx
+++ b/src/components/assets/AssetTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useQueryClient } from '@tanstack/react-query'
 import {
   type ColumnDef,
   flexRender,
@@ -53,6 +54,7 @@ export function AssetTable({ assets }: AssetTableProps) {
   const [deleteId, setDeleteId] = useState<string | null>(null)
   const { user } = useAuth()
   const { org } = useOrg()
+  const queryClient = useQueryClient()
   const deptLabel = org?.departmentLabel ?? 'Department'
   const tc = org?.assetTableConfig ?? {}
 
@@ -366,8 +368,11 @@ export function AssetTable({ assets }: AssetTableProps) {
         description="This will permanently remove the asset. This action cannot be undone."
         confirmLabel="Delete"
         destructive
-        onConfirm={() => {
-          if (deleteId) deleteAsset(deleteId)
+        onConfirm={async () => {
+          if (deleteId) {
+            await deleteAsset(deleteId)
+            queryClient.invalidateQueries({ queryKey: ['assets'] })
+          }
           setDeleteId(null)
         }}
       />


### PR DESCRIPTION
## Summary

- `deleteAsset` was called fire-and-forget — the React Query cache never got invalidated so the deleted asset stayed visible until the next background refetch
- Added `revalidatePath('/assets')` to the server action
- Both `AssetCard` and `AssetTable` now `await` the deletion and call `queryClient.invalidateQueries({ queryKey: ['assets'] })` so the list refreshes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)