### PR TITLE
feat: enforce permissions in all server action mutations

### DIFF
--- a/src/app/actions/__tests__/_helpers.ts
+++ b/src/app/actions/__tests__/_helpers.ts
@@ -1,6 +1,10 @@
 import { vi } from 'vitest'
 
-import type { ActionClients } from '../_context'
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { UserRole } from '@/lib/types'
+import { canEdit, canManage } from '@/lib/utils/permissions'
+
+import type { ActionClients, ActionContext } from '../_context'
 
 // ---------------------------------------------------------------------------
 // Chainable Supabase query builder stub
@@ -49,7 +53,7 @@ export function makeClients(
     } as unknown as NonNullable<ActionClients['supabase']>,
     admin: {
       from: vi.fn().mockReturnValue(chain),
-      auth: { admin: { inviteUserByEmail } },
+      auth: { admin: { inviteUserByEmail, deleteUser: vi.fn().mockResolvedValue({}) } },
     } as unknown as NonNullable<ActionClients['admin']>,
   }
 }
@@ -65,5 +69,27 @@ export function makeUnauthenticatedClients(chain: ReturnType<typeof makeChain>):
       from: vi.fn().mockReturnValue(chain),
       auth: { admin: {} },
     } as unknown as NonNullable<ActionClients['admin']>,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ActionContext factory — for unit-testing permission logic without going
+// through the full getContext() path
+// ---------------------------------------------------------------------------
+
+export function makeContext(overrides: Partial<ActionContext> = {}): ActionContext {
+  const role: UserRole = overrides.role ?? 'admin'
+  return {
+    userId: 'user-actor-0001',
+    orgId: 'org-0001',
+    actorName: 'Test Actor',
+    role,
+    departmentIds: [],
+    admin: {} as unknown as ReturnType<typeof createAdminClient>,
+    requireRole(level: 'editor' | 'admin') {
+      const allowed = level === 'admin' ? canManage(role) : canEdit(role)
+      return allowed ? null : { error: 'Not authorised' }
+    },
+    ...overrides,
   }
 }

--- a/src/app/actions/__tests__/assets.test.ts
+++ b/src/app/actions/__tests__/assets.test.ts
@@ -50,9 +50,21 @@ describe('createAsset', () => {
     expect(result).toEqual({ error: 'Not authenticated' })
   })
 
+  it('returns error when viewer tries to create an asset', async () => {
+    const clients = makeClients(chain)
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', full_name: 'User', role: 'viewer' },
+    })
+
+    const result = await createAsset(makeInput(), clients)
+    expect(result).toEqual({ error: 'Not authorised' })
+  })
+
   it('returns friendly error on duplicate asset tag (23505)', async () => {
     const clients = makeClients(chain)
-    chain.maybeSingle.mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User' } })
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', full_name: 'User', role: 'admin' },
+    })
     chain.single.mockResolvedValueOnce({
       data: null,
       error: { code: '23505', message: 'unique violation' },
@@ -64,7 +76,9 @@ describe('createAsset', () => {
 
   it('returns the new asset id on success', async () => {
     const clients = makeClients(chain)
-    chain.maybeSingle.mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User' } })
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', full_name: 'User', role: 'admin' },
+    })
     chain.single.mockResolvedValueOnce({ data: { id: 'asset-new-001' }, error: null })
 
     const result = await createAsset(makeInput(), clients)
@@ -83,15 +97,29 @@ describe('deleteAsset', () => {
     expect(result).toEqual({ error: 'Not authenticated' })
   })
 
+  it('returns error when viewer tries to delete an asset', async () => {
+    const clients = makeClients(chain)
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User', role: 'viewer' } })
+      .mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
+
+    const result = await deleteAsset('asset-0001', clients)
+    expect(result).toEqual({ error: 'Not authorised' })
+  })
+
   it('returns error when the database update fails', async () => {
     const clients = makeClients(chain)
     chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User' } })
-      .mockResolvedValueOnce({ data: { name: 'Test Laptop' } })
-    chain.then.mockImplementationOnce(
-      (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User', role: 'admin' } })
+      .mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
+    // getContext runs Promise.all — first `then` is consumed by user_departments query
+    chain.then
+      .mockImplementationOnce((resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+        Promise.resolve({ data: [], error: null }).then(resolve, reject)
+      )
+      .mockImplementationOnce((resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
         Promise.resolve({ data: null, error: { message: 'Row not found' } }).then(resolve, reject)
-    )
+      )
 
     const result = await deleteAsset('asset-0001', clients)
     expect(result).toEqual({ error: 'Row not found' })
@@ -100,8 +128,8 @@ describe('deleteAsset', () => {
   it('returns null on successful soft-delete', async () => {
     const clients = makeClients(chain)
     chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User' } })
-      .mockResolvedValueOnce({ data: { name: 'Test Laptop' } })
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User', role: 'admin' } })
+      .mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
 
     const result = await deleteAsset('asset-0001', clients)
     expect(result).toBeNull()

--- a/src/app/actions/__tests__/users.test.ts
+++ b/src/app/actions/__tests__/users.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 describe('updateUserRoleAction', () => {
   it('returns error when actor profile has no organisation', async () => {
     const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.single.mockResolvedValueOnce({ data: null })
+    chain.maybeSingle.mockResolvedValueOnce({ data: null })
 
     const result = await updateUserRoleAction(TARGET_ID, 'editor', clients)
 
@@ -33,7 +33,7 @@ describe('updateUserRoleAction', () => {
 
   it('returns error when actor role is not owner or admin', async () => {
     const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.single.mockResolvedValueOnce({
+    chain.maybeSingle.mockResolvedValueOnce({
       data: { org_id: 'org-0001', role: 'editor', full_name: 'Actor' },
     })
 
@@ -44,7 +44,7 @@ describe('updateUserRoleAction', () => {
 
   it('returns error when actor tries to change their own role', async () => {
     const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.single.mockResolvedValueOnce({
+    chain.maybeSingle.mockResolvedValueOnce({
       data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' },
     })
 
@@ -55,9 +55,10 @@ describe('updateUserRoleAction', () => {
 
   it('returns error when target user is not found in the org', async () => {
     const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.single
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' } })
-      .mockResolvedValueOnce({ data: null })
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' },
+    })
+    chain.single.mockResolvedValueOnce({ data: null })
 
     const result = await updateUserRoleAction(TARGET_ID, 'editor', clients)
 
@@ -66,9 +67,10 @@ describe('updateUserRoleAction', () => {
 
   it('returns error when target user is the org owner', async () => {
     const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.single
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' } })
-      .mockResolvedValueOnce({ data: { role: 'owner' } })
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' },
+    })
+    chain.single.mockResolvedValueOnce({ data: { role: 'owner', full_name: 'Owner' } })
 
     const result = await updateUserRoleAction(TARGET_ID, 'editor', clients)
 
@@ -77,10 +79,10 @@ describe('updateUserRoleAction', () => {
 
   it('returns null error on successful role change', async () => {
     const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.single
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' } })
-      .mockResolvedValueOnce({ data: { role: 'editor' } })
-    chain.maybeSingle.mockResolvedValueOnce({ data: { full_name: 'Target User' } })
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' },
+    })
+    chain.single.mockResolvedValueOnce({ data: { role: 'editor', full_name: 'Target User' } })
 
     const result = await updateUserRoleAction(TARGET_ID, 'viewer', clients)
 

--- a/src/app/actions/_context.ts
+++ b/src/app/actions/_context.ts
@@ -1,12 +1,16 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
+import type { UserRole } from '@/lib/types'
+import { canEdit, canManage } from '@/lib/utils/permissions'
 
 export type ActionContext = {
   userId: string
   orgId: string
   actorName: string
-
+  role: UserRole
+  departmentIds: string[]
   admin: ReturnType<typeof createAdminClient>
+  requireRole(level: 'editor' | 'admin'): { error: string } | null
 }
 
 export type ActionClients = {
@@ -22,17 +26,35 @@ export async function getContext(clients?: ActionClients): Promise<ActionContext
   if (!user) return null
 
   const admin = clients?.admin ?? createAdminClient()
-  const { data: profile } = await admin
-    .from('profiles')
-    .select('org_id, full_name')
-    .eq('id', user.id)
-    .maybeSingle()
+  const [{ data: profile }, { data: deptRows }] = await Promise.all([
+    admin.from('profiles').select('org_id, full_name, role').eq('id', user.id).maybeSingle(),
+    admin.from('user_departments').select('department_id').eq('user_id', user.id),
+  ])
 
   if (!profile?.org_id) return null
+  const role = profile.role as UserRole
+  const departmentIds = (deptRows ?? []).map((r: { department_id: string }) => r.department_id)
+
   return {
     userId: user.id,
     orgId: profile.org_id as string,
     actorName: (profile.full_name as string) ?? 'Unknown',
+    role,
+    departmentIds,
     admin,
+    requireRole(level: 'editor' | 'admin') {
+      const allowed = level === 'admin' ? canManage(role) : canEdit(role)
+      return allowed ? null : { error: 'Not authorised' }
+    },
   }
+}
+
+export function requireCanEdit(
+  ctx: ActionContext,
+  assetDepartmentId: string | null
+): { error: string } | null {
+  if (ctx.role === 'owner' || ctx.role === 'admin') return null
+  if (ctx.role === 'editor' && assetDepartmentId && ctx.departmentIds.includes(assetDepartmentId))
+    return null
+  return { error: 'Not authorised' }
 }

--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -11,7 +11,7 @@ import {
 
 import { logAudit } from './_audit'
 import type { ActionClients } from './_context'
-import { getContext } from './_context'
+import { getContext, requireCanEdit } from './_context'
 
 export async function createAsset(
   input: AssetFormInput,
@@ -22,6 +22,9 @@ export async function createAsset(
 
   const ctx = await getContext(clients)
   if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = requireCanEdit(ctx, input.departmentId ?? null)
+  if (denied) return denied
 
   const { data, error } = await ctx.admin
     .from('assets')
@@ -63,20 +66,24 @@ export async function createAsset(
 
 export async function updateAsset(
   id: string,
-  input: AssetFormInput
+  input: AssetFormInput,
+  clients?: ActionClients
 ): Promise<{ error: string } | null> {
   const parsed = AssetFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
+  const ctx = await getContext(clients)
   if (!ctx) return { error: 'Not authenticated' }
 
-  // Fetch old values for change tracking
+  // Fetch old values for change tracking and permission check
   const { data: old } = await ctx.admin
     .from('assets')
     .select('name, status, category_id, department_id, location_id, quantity')
     .eq('id', id)
     .maybeSingle()
+
+  const denied = requireCanEdit(ctx, (old?.department_id as string | null) ?? null)
+  if (denied) return denied
 
   const { error } = await ctx.admin
     .from('assets')
@@ -131,7 +138,14 @@ export async function deleteAsset(
   const ctx = await getContext(clients)
   if (!ctx) return { error: 'Not authenticated' }
 
-  const { data: asset } = await ctx.admin.from('assets').select('name').eq('id', id).maybeSingle()
+  const { data: asset } = await ctx.admin
+    .from('assets')
+    .select('name, department_id')
+    .eq('id', id)
+    .maybeSingle()
+
+  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  if (denied) return denied
 
   const { error } = await ctx.admin
     .from('assets')
@@ -166,9 +180,12 @@ export async function checkoutAsset(
 
   const { data: asset } = await ctx.admin
     .from('assets')
-    .select('name, quantity')
+    .select('name, quantity, department_id')
     .eq('id', assetId)
     .single()
+
+  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  if (denied) return denied
 
   if (isBulk) {
     const { data: activeRows } = await ctx.admin
@@ -241,9 +258,12 @@ export async function returnAsset(assetId: string): Promise<{ error: string } | 
 
   const { data: asset } = await ctx.admin
     .from('assets')
-    .select('name')
+    .select('name, department_id')
     .eq('id', assetId)
     .maybeSingle()
+
+  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  if (denied) return denied
 
   const { error: assignError } = await ctx.admin
     .from('asset_assignments')
@@ -284,11 +304,21 @@ export async function returnBulkAssignment(
 
   const { data: row } = await ctx.admin
     .from('asset_assignments')
-    .select('quantity, assigned_to_name, asset_id, assets(name)')
+    .select('quantity, assigned_to_name, asset_id, assets(name, department_id)')
     .eq('id', assignmentId)
     .single()
 
   if (!row) return { error: 'Assignment not found.' }
+
+  const assetJoin = row.assets as
+    | { name: string; department_id: string | null }
+    | { name: string; department_id: string | null }[]
+    | null
+  const assetDeptId =
+    (Array.isArray(assetJoin) ? assetJoin[0]?.department_id : assetJoin?.department_id) ?? null
+
+  const denied = requireCanEdit(ctx, assetDeptId)
+  if (denied) return denied
 
   const remaining = (row.quantity as number) - quantityToReturn
 
@@ -306,7 +336,6 @@ export async function returnBulkAssignment(
     if (error) return { error: error.message }
   }
 
-  const assetJoin = row.assets as { name: string } | { name: string }[] | null
   const assetName =
     (Array.isArray(assetJoin) ? assetJoin[0]?.name : assetJoin?.name) ?? 'Unknown asset'
 
@@ -334,9 +363,12 @@ export async function restockAsset(
 
   const { data: asset } = await ctx.admin
     .from('assets')
-    .select('name, quantity')
+    .select('name, quantity, department_id')
     .eq('id', assetId)
     .single()
+
+  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  if (denied) return denied
 
   const oldQuantity = (asset?.quantity ?? 0) as number
   const newQuantity = oldQuantity + additionalQuantity
@@ -373,9 +405,18 @@ export async function updateAssignment(
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
 
+  const { data: asset } = await ctx.admin
+    .from('assets')
+    .select('name, department_id')
+    .eq('id', assetId)
+    .maybeSingle()
+
+  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  if (denied) return denied
+
   if (isBulk) {
     // Validate: new quantity must not exceed available + what this assignment currently holds
-    const { data: asset } = await ctx.admin
+    const { data: stockRow } = await ctx.admin
       .from('assets')
       .select('quantity')
       .eq('id', assetId)
@@ -391,19 +432,13 @@ export async function updateAssignment(
     const otherCheckedOut = (activeRows ?? [])
       .filter((r: { id: string; quantity: number }) => r.id !== assignmentId)
       .reduce((sum: number, r: { quantity: number }) => sum + (r.quantity ?? 1), 0)
-    const maxAllowed = (asset?.quantity ?? 0) - otherCheckedOut
+    const maxAllowed = (stockRow?.quantity ?? 0) - otherCheckedOut
     if (input.quantity > maxAllowed) {
       return {
         error: `Only ${maxAllowed} available (${currentRow?.quantity ?? 0} currently on this assignment).`,
       }
     }
   }
-
-  const { data: asset } = await ctx.admin
-    .from('assets')
-    .select('name')
-    .eq('id', assetId)
-    .maybeSingle()
 
   const { error } = await ctx.admin
     .from('asset_assignments')

--- a/src/app/actions/categories.ts
+++ b/src/app/actions/categories.ts
@@ -14,6 +14,9 @@ export async function createCategory(
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
 
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
+
   const { data, error } = await ctx.admin
     .from('categories')
     .insert({
@@ -46,6 +49,9 @@ export async function updateCategory(
 
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
   const { error } = await ctx.admin
     .from('categories')
@@ -82,6 +88,9 @@ export async function countAssetsInCategory(id: string): Promise<number> {
 export async function deleteCategory(id: string): Promise<{ error: string } | null> {
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
   const { data: cat } = await ctx.admin.from('categories').select('name').eq('id', id).maybeSingle()
 

--- a/src/app/actions/departments.ts
+++ b/src/app/actions/departments.ts
@@ -14,6 +14,9 @@ export async function createDepartment(
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
 
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
+
   const { data, error } = await ctx.admin
     .from('departments')
     .insert({ org_id: ctx.orgId, name: input.name, description: input.description ?? null })
@@ -41,6 +44,9 @@ export async function updateDepartment(
 
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
   const { error } = await ctx.admin
     .from('departments')
@@ -77,6 +83,9 @@ export async function countAssetsInDepartment(id: string): Promise<number> {
 export async function deleteDepartment(id: string): Promise<{ error: string } | null> {
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
   const { data: dept } = await ctx.admin
     .from('departments')

--- a/src/app/actions/locations.ts
+++ b/src/app/actions/locations.ts
@@ -14,6 +14,9 @@ export async function createLocation(
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
 
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
+
   const { data, error } = await ctx.admin
     .from('locations')
     .insert({ org_id: ctx.orgId, name: input.name, description: input.description ?? null })
@@ -42,6 +45,9 @@ export async function updateLocation(
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
 
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
+
   const { error } = await ctx.admin
     .from('locations')
     .update({ name: input.name, description: input.description ?? null })
@@ -63,6 +69,9 @@ export async function updateLocation(
 export async function deleteLocation(id: string): Promise<{ error: string } | null> {
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
   const { data: loc } = await ctx.admin.from('locations').select('name').eq('id', id).maybeSingle()
 

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { headers } from 'next/headers'
-import { redirect } from 'next/navigation'
 
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
@@ -9,74 +8,45 @@ import type { UserRole } from '@/lib/types'
 
 import { logAudit } from './_audit'
 import type { ActionClients } from './_context'
-
-async function getActorProfile(clients?: ActionClients) {
-  const supabase = clients?.supabase ?? (await createClient())
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) redirect('/login')
-
-  const admin = clients?.admin ?? createAdminClient()
-  const { data: profile } = await admin
-    .from('profiles')
-    .select('org_id, role, full_name')
-    .eq('id', user.id)
-    .single()
-
-  return { actorId: user.id, profile, admin }
-}
+import { getContext } from './_context'
 
 export async function updateUserRoleAction(
   userId: string,
   role: Exclude<UserRole, 'owner'>,
   clients?: ActionClients
 ): Promise<{ error: string } | { error: null }> {
-  const { actorId, profile, admin } = await getActorProfile(clients)
+  const ctx = await getContext(clients)
+  if (!ctx) return { error: 'No organisation found' }
 
-  if (!profile?.org_id) return { error: 'No organisation found' }
-  if (!['owner', 'admin'].includes(profile.role)) return { error: 'Not authorised' }
-  if (userId === actorId) return { error: 'You cannot change your own role' }
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
-  // Prevent changing the org owner's role
-  const { data: target } = await admin
+  if (userId === ctx.userId) return { error: 'You cannot change your own role' }
+
+  const { data: target } = await ctx.admin
     .from('profiles')
-    .select('role')
+    .select('role, full_name')
     .eq('id', userId)
-    .eq('org_id', profile.org_id)
+    .eq('org_id', ctx.orgId)
     .single()
 
   if (!target) return { error: 'User not found' }
   if (target.role === 'owner') return { error: "Cannot change the owner's role" }
 
-  const { error } = await admin
+  const { error } = await ctx.admin
     .from('profiles')
     .update({ role })
     .eq('id', userId)
-    .eq('org_id', profile.org_id)
+    .eq('org_id', ctx.orgId)
 
   if (!error) {
-    const { data: targetProfile } = await admin
-      .from('profiles')
-      .select('full_name')
-      .eq('id', userId)
-      .maybeSingle()
-
-    await logAudit(
-      {
-        userId: actorId,
-        orgId: profile.org_id as string,
-        actorName: (profile.full_name as string) ?? 'Unknown',
-        admin,
-      },
-      {
-        entityType: 'user',
-        entityId: userId,
-        entityName: (targetProfile?.full_name as string) ?? 'Unknown user',
-        action: 'role_changed',
-        changes: { role: { old: target.role, new: role } },
-      }
-    )
+    await logAudit(ctx, {
+      entityType: 'user',
+      entityId: userId,
+      entityName: (target.full_name as string) ?? 'Unknown user',
+      action: 'role_changed',
+      changes: { role: { old: target.role, new: role } },
+    })
   }
 
   return { error: error?.message ?? null }
@@ -87,18 +57,22 @@ export async function updateUserDepartmentsAction(
   departmentIds: string[],
   clients?: ActionClients
 ): Promise<{ error: string } | { error: null }> {
-  const { profile, admin } = await getActorProfile(clients)
+  const ctx = await getContext(clients)
+  if (!ctx) return { error: 'No organisation found' }
 
-  if (!profile?.org_id) return { error: 'No organisation found' }
-  if (!['owner', 'admin'].includes(profile.role)) return { error: 'Not authorised' }
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
   // Replace all department memberships in a transaction-like manner
-  const { error: deleteError } = await admin.from('user_departments').delete().eq('user_id', userId)
+  const { error: deleteError } = await ctx.admin
+    .from('user_departments')
+    .delete()
+    .eq('user_id', userId)
 
   if (deleteError) return { error: deleteError.message }
 
   if (departmentIds.length > 0) {
-    const { error: insertError } = await admin
+    const { error: insertError } = await ctx.admin
       .from('user_departments')
       .insert(departmentIds.map((department_id) => ({ user_id: userId, department_id })))
     if (insertError) return { error: insertError.message }
@@ -111,24 +85,25 @@ export async function revokeInviteAction(
   inviteId: string,
   clients?: ActionClients
 ): Promise<{ error: string } | { error: null }> {
-  const { profile, admin } = await getActorProfile(clients)
+  const ctx = await getContext(clients)
+  if (!ctx) return { error: 'No organisation found' }
 
-  if (!profile?.org_id) return { error: 'No organisation found' }
-  if (!['owner', 'admin'].includes(profile.role)) return { error: 'Not authorised' }
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
   // Grab the email before deleting so we can clean up the auth user
-  const { data: invite } = await admin
+  const { data: invite } = await ctx.admin
     .from('invites')
     .select('email')
     .eq('id', inviteId)
-    .eq('org_id', profile.org_id)
+    .eq('org_id', ctx.orgId)
     .maybeSingle()
 
-  const { error } = await admin
+  const { error } = await ctx.admin
     .from('invites')
     .delete()
     .eq('id', inviteId)
-    .eq('org_id', profile.org_id)
+    .eq('org_id', ctx.orgId)
 
   if (error) return { error: error.message }
 
@@ -138,7 +113,7 @@ export async function revokeInviteAction(
   // The on_auth_user_created trigger creates a profile with org_id = null for
   // pending users, so we can look up the user ID that way.
   if (invite?.email) {
-    const { data: pendingProfile } = await admin
+    const { data: pendingProfile } = await ctx.admin
       .from('profiles')
       .select('id')
       .eq('email', invite.email)
@@ -146,7 +121,7 @@ export async function revokeInviteAction(
       .maybeSingle()
 
     if (pendingProfile) {
-      await admin.auth.admin.deleteUser(pendingProfile.id as string)
+      await ctx.admin.auth.admin.deleteUser(pendingProfile.id as string)
       // profile row is removed automatically via ON DELETE CASCADE on auth.users
     }
   }
@@ -158,32 +133,34 @@ export async function removeUserAction(
   userId: string,
   clients?: ActionClients
 ): Promise<{ error: string } | { error: null }> {
-  const { actorId, profile, admin } = await getActorProfile(clients)
+  const ctx = await getContext(clients)
+  if (!ctx) return { error: 'No organisation found' }
 
-  if (!profile?.org_id) return { error: 'No organisation found' }
-  if (!['owner', 'admin'].includes(profile.role)) return { error: 'Not authorised' }
-  if (userId === actorId) return { error: 'You cannot remove yourself' }
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
-  const { data: target } = await admin
+  if (userId === ctx.userId) return { error: 'You cannot remove yourself' }
+
+  const { data: target } = await ctx.admin
     .from('profiles')
     .select('role')
     .eq('id', userId)
-    .eq('org_id', profile.org_id)
+    .eq('org_id', ctx.orgId)
     .single()
 
   if (!target) return { error: 'User not found' }
   if (target.role === 'owner') return { error: 'Cannot remove the org owner' }
 
-  const { error } = await admin
+  const { error } = await ctx.admin
     .from('profiles')
     .update({ invite_status: 'deactivated' })
     .eq('id', userId)
-    .eq('org_id', profile.org_id)
+    .eq('org_id', ctx.orgId)
 
   if (error) return { error: error.message }
 
   // Delete the auth user so they can be re-invited cleanly later
-  await admin.auth.admin.deleteUser(userId)
+  await ctx.admin.auth.admin.deleteUser(userId)
 
   return { error: null }
 }

--- a/src/app/actions/vendors.ts
+++ b/src/app/actions/vendors.ts
@@ -14,6 +14,9 @@ export async function createVendor(
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
 
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
+
   const { data, error } = await ctx.admin
     .from('vendors')
     .insert({
@@ -49,6 +52,9 @@ export async function updateVendor(
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
 
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
+
   const { error } = await ctx.admin
     .from('vendors')
     .update({
@@ -76,6 +82,9 @@ export async function updateVendor(
 export async function deleteVendor(id: string): Promise<{ error: string } | null> {
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = ctx.requireRole('admin')
+  if (denied) return denied
 
   const { data: vendor } = await ctx.admin.from('vendors').select('name').eq('id', id).maybeSingle()
 


### PR DESCRIPTION
## Summary

- Closes #8 (RFC: enforce role/department permissions in server actions)
- `ActionContext` gains `role`, `departmentIds`, and `requireRole()` — permissions are now enforced at the call site of every mutating server action
- Viewers can no longer call `deleteAsset()`, `createDepartment()`, etc. directly; editors are scoped to their departments via `requireCanEdit()`
- `getActorProfile()` (private re-implementation of `getContext`) deleted from `users.ts`; all 4 user actions now use the shared `getContext()` path

## What changed

**`_context.ts`** — `ActionContext` adds `role`, `departmentIds`, `requireRole(level)` method; `getContext` uses `Promise.all` to fetch profile + departments in parallel; new `requireCanEdit(ctx, deptId)` helper for asset-level scoping

**`assets.ts`** — all 8 mutating actions (create, update, delete, checkout, return, returnBulk, restock, updateAssignment) call `requireCanEdit()` against the asset's `department_id`; `updateAsset` gains `clients?` param

**`users.ts`** — `getActorProfile` deleted; all 4 actions use `getContext() + ctx.requireRole('admin')`; `logAudit` receives `ctx` directly; target user fetch consolidated to single query returning `role, full_name`

**`departments/categories/locations/vendors.ts`** — every create/update/delete action gains `ctx.requireRole('admin')`

**Tests** — `makeContext()` helper added to `_helpers.ts`; profile mocks updated to include `role`; viewer-denial tests added for `createAsset`/`deleteAsset`; `users.test` migrated to `maybeSingle` for actor profile

## Test plan

- [x] `npm test` — 90 tests pass
- [x] `npm run type-check` — clean
- [x] `npm run lint` — no new errors (4 pre-existing react-compiler warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)