### PR TITLE
refactor: extract availability calculation into a single tested utility

### DIFF
--- a/src/app/(app)/assets/[id]/page.tsx
+++ b/src/app/(app)/assets/[id]/page.tsx
@@ -27,6 +27,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useAsset } from '@/lib/hooks/useAssets'
 import { useAssetHistory } from '@/lib/hooks/useAuditLogs'
 import type { AssetAssignment, AuditLog } from '@/lib/types'
+import { computeAvailable, computeMaxForEdit } from '@/lib/utils/availability'
 import { formatCurrency, formatDate, formatRelativeTime } from '@/lib/utils/formatters'
 import { canEdit } from '@/lib/utils/permissions'
 import { useAuth } from '@/providers/AuthProvider'
@@ -60,7 +61,9 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
   if (!asset) return notFound()
 
   const canEditAssets = user ? canEdit(user.role) : false
-  const available = asset.isBulk ? (asset.quantity ?? 0) - asset.quantityCheckedOut : null
+  const available = asset.isBulk
+    ? computeAvailable(asset.quantity ?? 0, asset.quantityCheckedOut)
+    : null
   const canCheckOut = asset.isBulk ? (available ?? 0) > 0 : asset.status !== 'checked_out'
 
   async function handleReturn() {
@@ -387,7 +390,11 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
           isBulk={asset.isBulk}
           maxQuantity={
             asset.isBulk
-              ? (asset.quantity ?? 0) - asset.quantityCheckedOut + editAssignment.quantity
+              ? computeMaxForEdit(
+                  asset.quantity ?? 0,
+                  asset.quantityCheckedOut,
+                  editAssignment.quantity
+                )
               : undefined
           }
           open={!!editAssignment}

--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -8,10 +8,31 @@ import {
   type AssetFormInput,
   type CheckoutFormInput,
 } from '@/lib/types'
+import { computeAvailable } from '@/lib/utils/availability'
 
 import { logAudit } from './_audit'
-import type { ActionClients } from './_context'
+import type { ActionClients, ActionContext } from './_context'
 import { getContext, requireCanEdit } from './_context'
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/** Sum of active checked-out quantities for an asset, optionally excluding one assignment. */
+async function fetchCheckedOut(
+  admin: ActionContext['admin'],
+  assetId: string,
+  excludeAssignmentId?: string
+): Promise<number> {
+  const { data: rows } = await admin
+    .from('asset_assignments')
+    .select('id, quantity')
+    .eq('asset_id', assetId)
+    .is('returned_at', null)
+  return ((rows ?? []) as { id: string; quantity: number }[])
+    .filter((r) => !excludeAssignmentId || r.id !== excludeAssignmentId)
+    .reduce((sum, r) => sum + (r.quantity ?? 1), 0)
+}
 
 export async function createAsset(
   input: AssetFormInput,
@@ -188,16 +209,8 @@ export async function checkoutAsset(
   if (denied) return denied
 
   if (isBulk) {
-    const { data: activeRows } = await ctx.admin
-      .from('asset_assignments')
-      .select('quantity')
-      .eq('asset_id', assetId)
-      .is('returned_at', null)
-    const checkedOut = (activeRows ?? []).reduce(
-      (sum: number, r: { quantity: number }) => sum + (r.quantity ?? 1),
-      0
-    )
-    const available = (asset?.quantity ?? 0) - checkedOut
+    const checkedOut = await fetchCheckedOut(ctx.admin, assetId)
+    const available = computeAvailable(asset?.quantity ?? 0, checkedOut)
     if (input.quantity > available) {
       return { error: `Only ${available} available in stock.` }
     }
@@ -405,9 +418,10 @@ export async function updateAssignment(
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
 
+  // quantity included here so no separate fetch is needed for bulk validation
   const { data: asset } = await ctx.admin
     .from('assets')
-    .select('name, department_id')
+    .select('name, department_id, quantity')
     .eq('id', assetId)
     .maybeSingle()
 
@@ -416,26 +430,14 @@ export async function updateAssignment(
 
   if (isBulk) {
     // Validate: new quantity must not exceed available + what this assignment currently holds
-    const { data: stockRow } = await ctx.admin
-      .from('assets')
-      .select('quantity')
-      .eq('id', assetId)
-      .single()
-    const { data: activeRows } = await ctx.admin
-      .from('asset_assignments')
-      .select('id, quantity')
-      .eq('asset_id', assetId)
-      .is('returned_at', null)
-    const currentRow = (activeRows ?? []).find(
-      (r: { id: string; quantity: number }) => r.id === assignmentId
-    )
-    const otherCheckedOut = (activeRows ?? [])
-      .filter((r: { id: string; quantity: number }) => r.id !== assignmentId)
-      .reduce((sum: number, r: { quantity: number }) => sum + (r.quantity ?? 1), 0)
-    const maxAllowed = (stockRow?.quantity ?? 0) - otherCheckedOut
+    const [checkedOutByOthers, { data: currentAsgn }] = await Promise.all([
+      fetchCheckedOut(ctx.admin, assetId, assignmentId),
+      ctx.admin.from('asset_assignments').select('quantity').eq('id', assignmentId).maybeSingle(),
+    ])
+    const maxAllowed = computeAvailable(asset?.quantity ?? 0, checkedOutByOthers)
     if (input.quantity > maxAllowed) {
       return {
-        error: `Only ${maxAllowed} available (${currentRow?.quantity ?? 0} currently on this assignment).`,
+        error: `Only ${maxAllowed} available (${(currentAsgn?.quantity as number | null) ?? 0} currently on this assignment).`,
       }
     }
   }

--- a/src/components/assets/AssetTable.tsx
+++ b/src/components/assets/AssetTable.tsx
@@ -38,6 +38,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import type { AssetWithRelations } from '@/lib/types'
+import { computeAvailable } from '@/lib/utils/availability'
 import { formatCurrency, formatDate } from '@/lib/utils/formatters'
 import { canEdit } from '@/lib/utils/permissions'
 import { useAuth } from '@/providers/AuthProvider'
@@ -178,7 +179,7 @@ export function AssetTable({ assets }: AssetTableProps) {
       cell: ({ row }) => {
         const asset = row.original
         if (asset.isBulk) {
-          const available = (asset.quantity ?? 0) - asset.quantityCheckedOut
+          const available = computeAvailable(asset.quantity ?? 0, asset.quantityCheckedOut)
           return (
             <Badge variant="secondary" className="text-xs">
               {available}/{asset.quantity} avail.

--- a/src/components/assets/CheckoutModal.tsx
+++ b/src/components/assets/CheckoutModal.tsx
@@ -34,6 +34,7 @@ import { useDepartments } from '@/lib/hooks/useDepartments'
 import { useLocations } from '@/lib/hooks/useLocations'
 import { CheckoutFormSchema, type CheckoutFormInput } from '@/lib/types'
 import type { AssetWithRelations } from '@/lib/types'
+import { computeAvailable } from '@/lib/utils/availability'
 import { useAuth } from '@/providers/AuthProvider'
 import { useOrg } from '@/providers/OrgProvider'
 
@@ -51,7 +52,9 @@ export function CheckoutModal({ asset, open, onOpenChange, onSuccess }: Checkout
   const { data: departments } = useDepartments()
   const { data: locations } = useLocations()
 
-  const available = asset.isBulk ? (asset.quantity ?? 0) - asset.quantityCheckedOut : null
+  const available = asset.isBulk
+    ? computeAvailable(asset.quantity ?? 0, asset.quantityCheckedOut)
+    : null
 
   const form = useForm<CheckoutFormInput>({
     resolver: zodResolver(CheckoutFormSchema),

--- a/src/lib/utils/__tests__/availability.test.ts
+++ b/src/lib/utils/__tests__/availability.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeAvailable, computeMaxForEdit } from '../availability'
+
+describe('computeAvailable', () => {
+  it('returns units remaining when some are checked out', () => {
+    expect(computeAvailable(10, 3)).toBe(7)
+  })
+
+  it('returns 0 when all units are checked out', () => {
+    expect(computeAvailable(5, 5)).toBe(0)
+  })
+
+  it('clamps to 0 when checked-out count exceeds total (data inconsistency)', () => {
+    expect(computeAvailable(3, 5)).toBe(0)
+  })
+
+  it('returns the full quantity when nothing is checked out', () => {
+    expect(computeAvailable(8, 0)).toBe(8)
+  })
+})
+
+describe('computeMaxForEdit', () => {
+  it('returns available + assignment quantity', () => {
+    // 10 total, 7 checked out (3 available), editing an assignment of 4 → max 7
+    expect(computeMaxForEdit(10, 7, 4)).toBe(7)
+  })
+
+  it('returns total when this is the only active assignment', () => {
+    // 10 total, 6 checked out all from this assignment → max 10
+    expect(computeMaxForEdit(10, 6, 6)).toBe(10)
+  })
+
+  it('clamps to 0 when the asset is over-allocated and the assignment contributes nothing', () => {
+    expect(computeMaxForEdit(3, 5, 0)).toBe(0)
+  })
+
+  it('returns assignment quantity when no other units are checked out', () => {
+    // 10 total, 2 checked out all from this assignment → max 10
+    expect(computeMaxForEdit(10, 2, 2)).toBe(10)
+  })
+})

--- a/src/lib/utils/availability.ts
+++ b/src/lib/utils/availability.ts
@@ -1,0 +1,19 @@
+/**
+ * How many units of a bulk asset are available for checkout.
+ * Clamps to 0 so the result is never negative.
+ */
+export function computeAvailable(totalQuantity: number, checkedOut: number): number {
+  return Math.max(0, totalQuantity - checkedOut)
+}
+
+/**
+ * Maximum units that can be requested when editing an existing assignment.
+ * = available units + what this assignment already holds.
+ */
+export function computeMaxForEdit(
+  totalQuantity: number,
+  checkedOut: number,
+  assignmentQuantity: number
+): number {
+  return Math.max(0, totalQuantity - checkedOut + assignmentQuantity)
+}


### PR DESCRIPTION
## Summary

- `computeAvailable` / `computeMaxForEdit` were inlined in 6 places with slightly different formulae and no tests; extracted to `src/lib/utils/availability.ts`
- Private `fetchCheckedOut` server helper consolidates the active-assignment DB query (with optional exclude for the edit case) that was duplicated between `checkoutAsset` and `updateAssignment`
- `updateAssignment` gains a bonus fix: `quantity` is added to the initial asset select, removing a redundant round-trip; the two availability queries are parallelised via `Promise.all`

## Changes

| File | Change |
|---|---|
| `src/lib/utils/availability.ts` | New — `computeAvailable`, `computeMaxForEdit` |
| `src/lib/utils/__tests__/availability.test.ts` | New — 8 unit tests |
| `src/app/actions/assets.ts` | `fetchCheckedOut` helper; wire `checkoutAsset` + `updateAssignment` |
| `CheckoutModal.tsx`, `AssetTable.tsx`, `assets/[id]/page.tsx` | Replace 4 inline formulas |

## Test plan

- [x] `npm test` — 98 tests pass (8 new)
- [x] `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)