### PR TITLE
refactor: consolidate asset tag generation into a single tested utility

### DIFF
--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -8,6 +8,7 @@ import {
   type AssetFormInput,
   type CheckoutFormInput,
 } from '@/lib/types'
+import { nextTagInSequence, sanitizePrefix } from '@/lib/utils/assetTag'
 import { computeAvailable } from '@/lib/utils/availability'
 
 import { logAudit } from './_audit'
@@ -469,20 +470,6 @@ export async function updateAssignment(
   return null
 }
 
-/** Count non-deleted assets in the org — used to generate the next asset tag */
-export async function getAssetCount(): Promise<number> {
-  const ctx = await getContext()
-  if (!ctx) return 0
-
-  const { count } = await ctx.admin
-    .from('assets')
-    .select('id', { count: 'exact', head: true })
-    .eq('org_id', ctx.orgId)
-    .is('deleted_at', null)
-
-  return count ?? 0
-}
-
 /** Return distinct tag prefixes used in the org (everything before the last '-') */
 export async function getTagPrefixes(): Promise<string[]> {
   const ctx = await getContext()
@@ -507,9 +494,11 @@ export async function getTagPrefixes(): Promise<string[]> {
 
 /** Return the next tag for a given prefix (e.g. "LAPTOP" → "LAPTOP-0001") */
 export async function getNextTagForPrefix(prefix: string): Promise<string> {
+  const sanitized = sanitizePrefix(prefix)
+  if (!sanitized) return `${prefix}-0001`
+
   const ctx = await getContext()
-  const sanitized = prefix.toUpperCase().replace(/[^A-Z0-9]/g, '')
-  if (!sanitized || !ctx) return `${sanitized || prefix}-0001`
+  if (!ctx) return `${sanitized}-0001`
 
   const { data } = await ctx.admin
     .from('assets')
@@ -518,14 +507,8 @@ export async function getNextTagForPrefix(prefix: string): Promise<string> {
     .is('deleted_at', null)
     .ilike('asset_tag', `${sanitized}-%`)
 
-  let max = 0
-  for (const { asset_tag } of (data ?? []) as { asset_tag: string }[]) {
-    const match = new RegExp(`^${sanitized}-(\\d+)$`, 'i').exec(asset_tag)
-    if (match) {
-      const n = parseInt(match[1], 10)
-      if (n > max) max = n
-    }
-  }
-
-  return `${sanitized}-${String(max + 1).padStart(4, '0')}`
+  return nextTagInSequence(
+    sanitized,
+    (data ?? []).map((r) => (r as { asset_tag: string }).asset_tag)
+  )
 }

--- a/src/components/assets/AssetForm.tsx
+++ b/src/components/assets/AssetForm.tsx
@@ -40,6 +40,7 @@ import { useLocationMutations, useLocations } from '@/lib/hooks/useLocations'
 import { useVendorMutations, useVendors } from '@/lib/hooks/useVendors'
 import { ASSET_STATUSES, AssetFormSchema, type AssetFormInput } from '@/lib/types'
 import type { AssetWithRelations } from '@/lib/types'
+import { parseTagParts } from '@/lib/utils/assetTag'
 import { useOrg } from '@/providers/OrgProvider'
 
 // ---------------------------------------------------------------------------
@@ -127,18 +128,10 @@ export function AssetForm({ asset, defaultAssetTag }: AssetFormProps) {
   // Prefix-based tag state (new assets only)
   // ---------------------------------------------------------------------------
 
-  // Split default tag into prefix + suffix (e.g. "AST-00001" → "AST", "00001")
-  const initialPrefix = (() => {
-    const tag = defaultAssetTag ?? 'AST-0001'
-    const idx = tag.lastIndexOf('-')
-    return idx > 0 ? tag.slice(0, idx) : 'AST'
-  })()
-
-  const initialSuffix = (() => {
-    const tag = defaultAssetTag ?? ''
-    const idx = tag.lastIndexOf('-')
-    return idx > 0 ? tag.slice(idx + 1) : '0001'
-  })()
+  // Split default tag into prefix + suffix (e.g. "AST-0001" → "AST", "0001")
+  const { prefix: initialPrefix, suffix: initialSuffix } = parseTagParts(
+    defaultAssetTag ?? 'AST-0001'
+  )
 
   const [prefix, setPrefix] = useState(initialPrefix)
   const [tagSuffix, setTagSuffix] = useState(initialSuffix)

--- a/src/lib/hooks/useAssets.ts
+++ b/src/lib/hooks/useAssets.ts
@@ -1,10 +1,10 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 
-import { getAssetCount } from '@/app/actions/assets'
+import { getNextTagForPrefix } from '@/app/actions/assets'
+import { ASSET_TAG_PREFIX } from '@/lib/constants'
 import { createClient } from '@/lib/supabase/client'
 import type { AssetAssignment, AssetStatus, AssetWithRelations } from '@/lib/types'
-import { generateAssetTag } from '@/lib/utils/formatters'
 import { canManage } from '@/lib/utils/permissions'
 import { useAuth } from '@/providers/AuthProvider'
 
@@ -241,16 +241,13 @@ export function useAsset(id: string): {
 }
 
 // ---------------------------------------------------------------------------
-// useNextAssetTag — generates the next tag based on total asset count
+// useNextAssetTag — max-based suggestion for the default "AST" prefix
 // ---------------------------------------------------------------------------
 
 export function useNextAssetTag(): string {
-  const { data: tag = 'AST-00001' } = useQuery({
+  const { data: tag = 'AST-0001' } = useQuery({
     queryKey: ['nextAssetTag'],
-    queryFn: async () => {
-      const count = await getAssetCount()
-      return generateAssetTag(count + 1)
-    },
+    queryFn: () => getNextTagForPrefix(ASSET_TAG_PREFIX),
     staleTime: 0, // Always fresh — tag must not be stale
   })
 

--- a/src/lib/utils/__tests__/assetTag.test.ts
+++ b/src/lib/utils/__tests__/assetTag.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { nextTagInSequence, parseTagParts, sanitizePrefix } from '../assetTag'
+
+// ---------------------------------------------------------------------------
+// sanitizePrefix
+// ---------------------------------------------------------------------------
+
+describe('sanitizePrefix', () => {
+  it('uppercases lowercase letters', () => {
+    expect(sanitizePrefix('laptop')).toBe('LAPTOP')
+  })
+
+  it('strips non-alphanumeric characters', () => {
+    expect(sanitizePrefix('IT-DEPT')).toBe('ITDEPT')
+    expect(sanitizePrefix('my prefix!')).toBe('MYPREFIX')
+  })
+
+  it('returns empty string for an all-symbol input', () => {
+    expect(sanitizePrefix('---')).toBe('')
+  })
+
+  it('passes through already-clean input unchanged', () => {
+    expect(sanitizePrefix('AST')).toBe('AST')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// nextTagInSequence
+// ---------------------------------------------------------------------------
+
+describe('nextTagInSequence', () => {
+  it('returns prefix-0001 when no existing tags match', () => {
+    expect(nextTagInSequence('AST', [])).toBe('AST-0001')
+    expect(nextTagInSequence('AST', ['LAPTOP-0001', 'PHONE-0003'])).toBe('AST-0001')
+  })
+
+  it('increments past the highest existing number', () => {
+    expect(nextTagInSequence('AST', ['AST-0001', 'AST-0002', 'AST-0003'])).toBe('AST-0004')
+  })
+
+  it('handles gaps in the sequence', () => {
+    expect(nextTagInSequence('AST', ['AST-0001', 'AST-0010'])).toBe('AST-0011')
+  })
+
+  it('pads to 4 digits', () => {
+    expect(nextTagInSequence('AST', ['AST-0009'])).toBe('AST-0010')
+    expect(nextTagInSequence('AST', [])).toBe('AST-0001')
+  })
+
+  it('exceeds 4-digit padding for large sequences', () => {
+    expect(nextTagInSequence('AST', ['AST-9999'])).toBe('AST-10000')
+  })
+
+  it('matches case-insensitively', () => {
+    expect(nextTagInSequence('AST', ['ast-0005'])).toBe('AST-0006')
+  })
+
+  it('ignores tags whose suffix is not purely numeric', () => {
+    expect(nextTagInSequence('AST', ['AST-001A', 'AST-0002'])).toBe('AST-0003')
+  })
+
+  it('handles existing tags with extra leading zeros correctly', () => {
+    // parseInt('0005') = 5, so next is 6
+    expect(nextTagInSequence('AST', ['AST-0005'])).toBe('AST-0006')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseTagParts
+// ---------------------------------------------------------------------------
+
+describe('parseTagParts', () => {
+  it('splits a standard tag into prefix and suffix', () => {
+    expect(parseTagParts('LAPTOP-0042')).toEqual({ prefix: 'LAPTOP', suffix: '0042' })
+  })
+
+  it('handles multi-part prefixes by splitting on the last dash', () => {
+    expect(parseTagParts('IT-DEPT-0001')).toEqual({ prefix: 'IT-DEPT', suffix: '0001' })
+  })
+
+  it('returns full string as prefix when no dash is present', () => {
+    expect(parseTagParts('NODASH')).toEqual({ prefix: 'NODASH', suffix: '0001' })
+  })
+
+  it('treats leading dash as no-split case', () => {
+    // lastIndexOf('-') === 0 → idx is not > 0, so falls back
+    expect(parseTagParts('-0001')).toEqual({ prefix: '-0001', suffix: '0001' })
+  })
+})

--- a/src/lib/utils/__tests__/formatters.test.ts
+++ b/src/lib/utils/__tests__/formatters.test.ts
@@ -7,7 +7,6 @@ import {
   formatDate,
   formatDateTime,
   formatRelativeTime,
-  generateAssetTag,
   getInitials,
   slugify,
 } from '@/lib/utils/formatters'
@@ -102,28 +101,6 @@ describe('formatRelativeTime', () => {
 
   it('returns a relative string ending with "ago" for a past date', () => {
     expect(formatRelativeTime('2020-01-01T00:00:00Z')).toMatch(/ago$/)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// generateAssetTag
-// ---------------------------------------------------------------------------
-
-describe('generateAssetTag', () => {
-  it('pads single digits to 5 places', () => {
-    expect(generateAssetTag(1)).toBe('AST-00001')
-  })
-
-  it('pads double digits', () => {
-    expect(generateAssetTag(42)).toBe('AST-00042')
-  })
-
-  it('handles exactly 5 digits', () => {
-    expect(generateAssetTag(99999)).toBe('AST-99999')
-  })
-
-  it('does not truncate beyond 5 digits', () => {
-    expect(generateAssetTag(100000)).toBe('AST-100000')
   })
 })
 

--- a/src/lib/utils/assetTag.ts
+++ b/src/lib/utils/assetTag.ts
@@ -1,0 +1,41 @@
+/**
+ * Strip a raw prefix string to uppercase alphanumeric characters only.
+ * "laptop 15" → "LAPTOP15", "IT-DEPT" → "ITDEPT"
+ */
+export function sanitizePrefix(raw: string): string {
+  return raw.toUpperCase().replace(/[^A-Z0-9]/g, '')
+}
+
+/**
+ * Given a sanitized prefix and a list of existing asset tags, return the
+ * next tag in the sequence.
+ *
+ * Finds the highest numeric suffix among tags matching `${prefix}-{digits}`,
+ * then returns `${prefix}-{max+1}` zero-padded to 4 characters.
+ *
+ * NOTE: This is a suggestion, not a reservation. Two concurrent users can
+ * receive the same suggested tag; the unique constraint on `asset_tag`
+ * surfaces this as a user-friendly error on insert.
+ */
+export function nextTagInSequence(sanitizedPrefix: string, existingTags: string[]): string {
+  const pattern = new RegExp(`^${sanitizedPrefix}-(\\d+)$`, 'i')
+  let max = 0
+  for (const tag of existingTags) {
+    const match = pattern.exec(tag)
+    if (match) {
+      const n = parseInt(match[1], 10)
+      if (n > max) max = n
+    }
+  }
+  return `${sanitizedPrefix}-${String(max + 1).padStart(4, '0')}`
+}
+
+/**
+ * Split a tag like "LAPTOP-0042" into its prefix and suffix parts.
+ * Falls back to `{ prefix: tag, suffix: '0001' }` when there is no `-`.
+ */
+export function parseTagParts(tag: string): { prefix: string; suffix: string } {
+  const idx = tag.lastIndexOf('-')
+  if (idx > 0) return { prefix: tag.slice(0, idx), suffix: tag.slice(idx + 1) }
+  return { prefix: tag, suffix: '0001' }
+}

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -1,7 +1,5 @@
 import { format, formatDistanceToNow, parseISO } from 'date-fns'
 
-import { ASSET_TAG_PREFIX } from '@/lib/constants'
-
 export function formatCurrency(value: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value)
 }
@@ -31,11 +29,6 @@ export function formatRelativeTime(dateStr: string | null | undefined): string {
   } catch {
     return '—'
   }
-}
-
-/** Generate the next asset tag given a running count, e.g. "AST-00042" */
-export function generateAssetTag(count: number): string {
-  return `${ASSET_TAG_PREFIX}-${String(count).padStart(5, '0')}`
 }
 
 /** Auto-generate an org slug from a name */


### PR DESCRIPTION
## Summary

- `generateAssetTag` (count-based, 5-digit padding) and `getNextTagForPrefix` (max-based, 4-digit padding) were two separate code paths for the same concept, with inconsistent output and no tests for the core logic
- `useNextAssetTag` used the count-based path — meaning deleted assets caused it to suggest already-used tags
- `AssetForm` duplicated the `lastIndexOf('-')` split twice as inline IIFEs

## Changes

| File | Change |
|---|---|
| `src/lib/utils/assetTag.ts` | New — `sanitizePrefix`, `nextTagInSequence` (max-based, 4-digit, race comment), `parseTagParts` |
| `src/lib/utils/__tests__/assetTag.test.ts` | New — 16 unit tests |
| `assets.ts` | `getNextTagForPrefix` delegates to pure functions; `getAssetCount` deleted (no callers) |
| `useAssets.ts` | `useNextAssetTag` calls `getNextTagForPrefix(ASSET_TAG_PREFIX)` — max-based, fixes stale-tag-after-deletion |
| `formatters.ts` | `generateAssetTag` deleted |
| `formatters.test.ts` | `generateAssetTag` tests deleted |
| `AssetForm.tsx` | Two IIFEs replaced with `parseTagParts` |

## Test plan

- [x] `npm test` — 110 tests pass (16 new)
- [x] `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)