### PR TITLE
fix: remove transform from PageTransition to unbreak fixed positioning

### DIFF
--- a/src/components/motion/PageTransition.tsx
+++ b/src/components/motion/PageTransition.tsx
@@ -10,8 +10,8 @@ export function PageTransition({ children }: { children: React.ReactNode }) {
   return (
     <motion.div
       key={pathname}
-      initial={{ opacity: 0, transform: 'translateY(6px)' }}
-      animate={{ opacity: 1, transform: 'translateY(0px)' }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
       transition={{ duration: 0.18, ease: easeOut }}
     >
       {children}


### PR DESCRIPTION
## Summary
- `framer-motion`'s `translateY` on `PageTransition` was creating a new CSS containing block, causing `position: fixed` elements to anchor to the animated div instead of the viewport
- The unsaved-changes bar in settings (`/settings/org`) was the affected element
- Fix: drop the `transform`/`translateY` from the animation — page fade still works

## Test plan
- [ ] Navigate to Settings → make a change → confirm the unsaved-changes bar sticks to the bottom of the viewport while scrolling
- [ ] Page transitions still fade in correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)