### PR TITLE
refactor: collapse repeated auth boilerplate into getAdminCtx helper

### DIFF
--- a/src/app/actions/_context.ts
+++ b/src/app/actions/_context.ts
@@ -49,6 +49,13 @@ export async function getContext(clients?: ActionClients): Promise<ActionContext
   }
 }
 
+/** Get context and assert admin role in one call. Returns the context or an error object. */
+export async function getAdminCtx(): Promise<ActionContext | { error: string }> {
+  const ctx = await getContext()
+  if (!ctx) return { error: 'Not authenticated' }
+  return ctx.requireRole('admin') ?? ctx
+}
+
 export function requireCanEdit(
   ctx: ActionContext,
   assetDepartmentId: string | null

--- a/src/app/actions/categories.ts
+++ b/src/app/actions/categories.ts
@@ -3,7 +3,7 @@
 import { CategoryFormSchema, type CategoryFormInput } from '@/lib/types'
 
 import { logAudit } from './_audit'
-import { getContext } from './_context'
+import { getAdminCtx, getContext } from './_context'
 
 export async function createCategory(
   input: CategoryFormInput
@@ -11,11 +11,8 @@ export async function createCategory(
   const parsed = CategoryFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { data, error } = await ctx.admin
     .from('categories')
@@ -47,11 +44,8 @@ export async function updateCategory(
   const parsed = CategoryFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { error } = await ctx.admin
     .from('categories')
@@ -86,11 +80,8 @@ export async function countAssetsInCategory(id: string): Promise<number> {
 }
 
 export async function deleteCategory(id: string): Promise<{ error: string } | null> {
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { data: cat } = await ctx.admin.from('categories').select('name').eq('id', id).maybeSingle()
 

--- a/src/app/actions/departments.ts
+++ b/src/app/actions/departments.ts
@@ -3,7 +3,7 @@
 import { DepartmentFormSchema, type DepartmentFormInput } from '@/lib/types'
 
 import { logAudit } from './_audit'
-import { getContext } from './_context'
+import { getAdminCtx, getContext } from './_context'
 
 export async function createDepartment(
   input: DepartmentFormInput
@@ -11,11 +11,8 @@ export async function createDepartment(
   const parsed = DepartmentFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { data, error } = await ctx.admin
     .from('departments')
@@ -42,11 +39,8 @@ export async function updateDepartment(
   const parsed = DepartmentFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { error } = await ctx.admin
     .from('departments')
@@ -81,11 +75,8 @@ export async function countAssetsInDepartment(id: string): Promise<number> {
 }
 
 export async function deleteDepartment(id: string): Promise<{ error: string } | null> {
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { data: dept } = await ctx.admin
     .from('departments')

--- a/src/app/actions/locations.ts
+++ b/src/app/actions/locations.ts
@@ -3,7 +3,7 @@
 import { LocationFormSchema, type LocationFormInput } from '@/lib/types'
 
 import { logAudit } from './_audit'
-import { getContext } from './_context'
+import { getAdminCtx } from './_context'
 
 export async function createLocation(
   input: LocationFormInput
@@ -11,11 +11,8 @@ export async function createLocation(
   const parsed = LocationFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { data, error } = await ctx.admin
     .from('locations')
@@ -42,11 +39,8 @@ export async function updateLocation(
   const parsed = LocationFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { error } = await ctx.admin
     .from('locations')
@@ -67,11 +61,8 @@ export async function updateLocation(
 }
 
 export async function deleteLocation(id: string): Promise<{ error: string } | null> {
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { data: loc } = await ctx.admin.from('locations').select('name').eq('id', id).maybeSingle()
 

--- a/src/app/actions/vendors.ts
+++ b/src/app/actions/vendors.ts
@@ -3,7 +3,7 @@
 import { VendorFormSchema, type VendorFormInput } from '@/lib/types'
 
 import { logAudit } from './_audit'
-import { getContext } from './_context'
+import { getAdminCtx } from './_context'
 
 export async function createVendor(
   input: VendorFormInput
@@ -11,11 +11,8 @@ export async function createVendor(
   const parsed = VendorFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { data, error } = await ctx.admin
     .from('vendors')
@@ -49,11 +46,8 @@ export async function updateVendor(
   const parsed = VendorFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { error } = await ctx.admin
     .from('vendors')
@@ -80,11 +74,8 @@ export async function updateVendor(
 }
 
 export async function deleteVendor(id: string): Promise<{ error: string } | null> {
-  const ctx = await getContext()
-  if (!ctx) return { error: 'Not authenticated' }
-
-  const denied = ctx.requireRole('admin')
-  if (denied) return denied
+  const ctx = await getAdminCtx()
+  if ('error' in ctx) return ctx
 
   const { data: vendor } = await ctx.admin.from('vendors').select('name').eq('id', id).maybeSingle()
 


### PR DESCRIPTION
## Summary
- Added `getAdminCtx()` to `_context.ts` — combines `getContext()` + `requireRole('admin')` into a single call returning `ActionContext | { error: string }`
- Replaced the 4-line auth block repeated 10× across `categories`, `departments`, `locations`, and `vendors` actions with a clean 2-line pattern
- Net: −64 / +35 lines across 5 files

## Test plan
- [ ] All 110 existing tests pass
- [ ] TypeScript type-check passes
- [ ] No behavior change — same auth semantics, just extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)