### PR TITLE
refactor: unify duplicate dept-level edit logic into canEditInDepartment

### DIFF
--- a/src/app/actions/_context.ts
+++ b/src/app/actions/_context.ts
@@ -1,7 +1,7 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import type { UserRole } from '@/lib/types'
-import { canEdit, canManage } from '@/lib/utils/permissions'
+import { canEdit, canEditInDepartment, canManage } from '@/lib/utils/permissions'
 
 export type ActionContext = {
   userId: string
@@ -53,8 +53,7 @@ export function requireCanEdit(
   ctx: ActionContext,
   assetDepartmentId: string | null
 ): { error: string } | null {
-  if (ctx.role === 'owner' || ctx.role === 'admin') return null
-  if (ctx.role === 'editor' && assetDepartmentId && ctx.departmentIds.includes(assetDepartmentId))
-    return null
-  return { error: 'Not authorised' }
+  return canEditInDepartment(ctx.role, ctx.departmentIds, assetDepartmentId)
+    ? null
+    : { error: 'Not authorised' }
 }

--- a/src/lib/utils/__tests__/permissions.test.ts
+++ b/src/lib/utils/__tests__/permissions.test.ts
@@ -4,6 +4,7 @@ import type { AssetWithRelations, ProfileWithDepartments } from '@/lib/types'
 import {
   canEdit,
   canEditAsset,
+  canEditInDepartment,
   canManage,
   canViewAsset,
   canViewDepartment,
@@ -138,6 +139,38 @@ describe('canViewDepartment', () => {
 
   it('denies access to viewer not assigned to that department', () => {
     expect(canViewDepartment(makeUser('viewer', []), DEPT_A)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// canEditInDepartment
+// ---------------------------------------------------------------------------
+
+describe('canEditInDepartment', () => {
+  it('allows owner regardless of department', () => {
+    expect(canEditInDepartment('owner', [], null)).toBe(true)
+    expect(canEditInDepartment('owner', [], DEPT_A)).toBe(true)
+  })
+
+  it('allows admin regardless of department', () => {
+    expect(canEditInDepartment('admin', [], null)).toBe(true)
+    expect(canEditInDepartment('admin', [], DEPT_A)).toBe(true)
+  })
+
+  it('allows editor in their assigned department', () => {
+    expect(canEditInDepartment('editor', [DEPT_A], DEPT_A)).toBe(true)
+  })
+
+  it('denies editor in a different department', () => {
+    expect(canEditInDepartment('editor', [DEPT_B], DEPT_A)).toBe(false)
+  })
+
+  it('denies editor when asset has no department', () => {
+    expect(canEditInDepartment('editor', [DEPT_A], null)).toBe(false)
+  })
+
+  it('denies viewer regardless of department', () => {
+    expect(canEditInDepartment('viewer', [DEPT_A], DEPT_A)).toBe(false)
   })
 })
 

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -16,13 +16,23 @@ export function canViewDepartment(user: ProfileWithDepartments, departmentId: st
   return user.departmentIds.includes(departmentId)
 }
 
+/**
+ * Core department-level edit check: can this role/dept-list edit an asset in a given department?
+ * Single source of truth shared by both the server-side requireCanEdit and the client-side canEditAsset.
+ */
+export function canEditInDepartment(
+  role: UserRole,
+  departmentIds: string[],
+  assetDepartmentId: string | null
+): boolean {
+  if (role === 'owner' || role === 'admin') return true
+  if (role === 'editor' && assetDepartmentId) return departmentIds.includes(assetDepartmentId)
+  return false
+}
+
 /** Whether the user can edit/delete a specific asset */
 export function canEditAsset(user: ProfileWithDepartments, asset: AssetWithRelations): boolean {
-  if (canManage(user.role)) return true
-  if (user.role === 'editor' && asset.departmentId) {
-    return user.departmentIds.includes(asset.departmentId)
-  }
-  return false
+  return canEditInDepartment(user.role, user.departmentIds, asset.departmentId ?? null)
 }
 
 /** Whether the user can see the asset (viewer or above in same dept) */


### PR DESCRIPTION
## Summary
- `requireCanEdit` in `_context.ts` and `canEditAsset` in `permissions.ts` independently implemented the same owner/admin/editor-dept logic
- Extracted `canEditInDepartment(role, departmentIds, assetDepartmentId)` as the single source of truth in `permissions.ts`
- Both functions now delegate to it — one role hierarchy change touches one place
- Added 6 boundary tests for the new canonical function

## Test plan
- [ ] All 116 tests pass (6 new for `canEditInDepartment`)
- [ ] TypeScript type-check passes
- [ ] No behavior change — same auth semantics throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)