### PR TITLE
fix: close race conditions and silent failures in multi-step actions

### DIFF
--- a/src/app/actions/__tests__/assets.test.ts
+++ b/src/app/actions/__tests__/assets.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import type { AssetFormInput } from '@/lib/types'
+import type { AssetFormInput, CheckoutFormInput } from '@/lib/types'
 
-import { createAsset, deleteAsset } from '../assets'
+import { checkoutAsset, createAsset, deleteAsset } from '../assets'
 
 import { makeChain, makeClients, makeUnauthenticatedClients } from './_helpers'
 
@@ -132,6 +132,126 @@ describe('deleteAsset', () => {
       .mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
 
     const result = await deleteAsset('asset-0001', clients)
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkoutAsset
+// ---------------------------------------------------------------------------
+
+function makeCheckoutInput(overrides: Partial<CheckoutFormInput> = {}): CheckoutFormInput {
+  return {
+    assignedToUserId: '00000000-0000-4000-8000-000000000001',
+    assignedToName: 'Alice',
+    quantity: 1,
+    departmentId: null,
+    locationId: null,
+    expectedReturnAt: null,
+    notes: undefined,
+    ...overrides,
+  }
+}
+
+/** Helper: mock a fetchCheckedOut call (uses chain.then) */
+function mockFetchCheckedOut(
+  chain: ReturnType<typeof makeChain>,
+  rows: { id: string; quantity: number }[]
+) {
+  chain.then.mockImplementationOnce((resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+    Promise.resolve({ data: rows, error: null }).then(resolve, reject)
+  )
+}
+
+describe('checkoutAsset', () => {
+  it('returns error when user is not authenticated', async () => {
+    const clients = makeUnauthenticatedClients(chain)
+    const result = await checkoutAsset('asset-0001', makeCheckoutInput(), 'Admin', false, clients)
+    expect(result).toEqual({ error: 'Not authenticated' })
+  })
+
+  it('rejects bulk checkout when pre-check shows insufficient stock', async () => {
+    const clients = makeClients(chain)
+    // getContext: profile + user_departments
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' },
+    })
+    chain.then.mockImplementationOnce(
+      (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+        Promise.resolve({ data: [], error: null }).then(resolve, reject)
+    )
+    // asset fetch: quantity=2, 2 already checked out → 0 available
+    chain.single.mockResolvedValueOnce({
+      data: { name: 'Laptop', quantity: 2, department_id: null },
+    })
+    // pre-check fetchCheckedOut → 2 checked out
+    mockFetchCheckedOut(chain, [
+      { id: 'asgn-001', quantity: 1 },
+      { id: 'asgn-002', quantity: 1 },
+    ])
+
+    const result = await checkoutAsset(
+      'asset-0001',
+      makeCheckoutInput({ quantity: 1 }),
+      'Admin',
+      true,
+      clients
+    )
+    expect(result).toEqual({ error: 'Only 0 available in stock.' })
+  })
+
+  it('rolls back assignment and returns error when post-insert re-check detects over-allocation', async () => {
+    const clients = makeClients(chain)
+    // getContext: profile + user_departments
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' },
+    })
+    chain.then.mockImplementationOnce(
+      (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+        Promise.resolve({ data: [], error: null }).then(resolve, reject)
+    )
+    // asset fetch: quantity=1
+    chain.single
+      .mockResolvedValueOnce({ data: { name: 'Laptop', quantity: 1, department_id: null } })
+      // insert.select.single → assignment ID
+      .mockResolvedValueOnce({ data: { id: 'asgn-new-001' }, error: null })
+    // pre-check fetchCheckedOut → 0 checked out (passes fast-path)
+    mockFetchCheckedOut(chain, [])
+    // post-insert fetchCheckedOut → 2 total (concurrent checkout snuck in)
+    mockFetchCheckedOut(chain, [
+      { id: 'asgn-concurrent', quantity: 1 },
+      { id: 'asgn-new-001', quantity: 1 },
+    ])
+
+    const result = await checkoutAsset(
+      'asset-0001',
+      makeCheckoutInput({ quantity: 1 }),
+      'Admin',
+      true,
+      clients
+    )
+    expect(result).toEqual({ error: 'This item just went out of stock. Please try again.' })
+    // Rollback by assignment ID
+    expect(chain.eq).toHaveBeenCalledWith('id', 'asgn-new-001')
+  })
+
+  it('returns null on successful serialized checkout', async () => {
+    const clients = makeClients(chain)
+    // getContext: profile + user_departments
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' },
+    })
+    chain.then.mockImplementationOnce(
+      (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+        Promise.resolve({ data: [], error: null }).then(resolve, reject)
+    )
+    // asset fetch
+    chain.single
+      .mockResolvedValueOnce({ data: { name: 'Laptop', quantity: null, department_id: null } })
+      // insert.select.single
+      .mockResolvedValueOnce({ data: { id: 'asgn-new-001' }, error: null })
+
+    const result = await checkoutAsset('asset-0001', makeCheckoutInput(), 'Admin', false, clients)
     expect(result).toBeNull()
   })
 })

--- a/src/app/actions/__tests__/invites.test.ts
+++ b/src/app/actions/__tests__/invites.test.ts
@@ -42,24 +42,32 @@ describe('sendInviteAction', () => {
     expect(result).toEqual({ error: 'A pending invite already exists for this email' })
   })
 
-  it('rolls back the invite row and returns error when auth invite fails', async () => {
+  it('rolls back the invite row by ID and returns error when auth invite fails', async () => {
     mockInviteUserByEmail.mockResolvedValueOnce({ error: { message: 'SMTP unavailable' } })
     const clients = makeClients(chain, { inviteUserByEmail: mockInviteUserByEmail })
-    chain.single.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
-    })
+    chain.single
+      .mockResolvedValueOnce({
+        data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
+      })
+      // insert.select.single — returns the new invite's ID
+      .mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
     chain.maybeSingle.mockResolvedValueOnce({ data: null })
 
     const result = await sendInviteAction('new@example.com', 'editor', [], clients)
 
     expect(result).toEqual({ error: 'SMTP unavailable' })
+    // Rollback should target the specific invite ID, not email+org
+    expect(chain.eq).toHaveBeenCalledWith('id', 'new-invite-001')
   })
 
   it('returns null error on success', async () => {
     const clients = makeClients(chain, { inviteUserByEmail: mockInviteUserByEmail })
-    chain.single.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
-    })
+    chain.single
+      .mockResolvedValueOnce({
+        data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
+      })
+      // insert.select.single
+      .mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
     chain.maybeSingle.mockResolvedValueOnce({ data: null })
 
     const result = await sendInviteAction('new@example.com', 'viewer', [], clients)

--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -192,12 +192,13 @@ export async function checkoutAsset(
   assetId: string,
   input: CheckoutFormInput,
   assignedByName: string,
-  isBulk: boolean
+  isBulk: boolean,
+  clients?: ActionClients
 ): Promise<{ error: string } | null> {
   const parsed = CheckoutFormSchema.safeParse(input)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const ctx = await getContext()
+  const ctx = await getContext(clients)
   if (!ctx) return { error: 'Not authenticated' }
 
   const { data: asset } = await ctx.admin
@@ -209,6 +210,7 @@ export async function checkoutAsset(
   const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
   if (denied) return denied
 
+  // Fast-path: reject immediately if obviously out of stock
   if (isBulk) {
     const checkedOut = await fetchCheckedOut(ctx.admin, assetId)
     const available = computeAvailable(asset?.quantity ?? 0, checkedOut)
@@ -217,22 +219,39 @@ export async function checkoutAsset(
     }
   }
 
-  const { error: assignError } = await ctx.admin.from('asset_assignments').insert({
-    asset_id: assetId,
-    assigned_to_user_id: input.assignedToUserId,
-    assigned_to_name: input.assignedToName,
-    assigned_by: ctx.userId,
-    assigned_by_name: assignedByName,
-    quantity: input.quantity,
-    department_id: input.departmentId || null,
-    location_id: input.locationId || null,
-    expected_return_at: input.expectedReturnAt
-      ? new Date(input.expectedReturnAt).toISOString()
-      : null,
-    notes: input.notes || null,
-  })
+  // Insert first, then re-verify for bulk assets — catches concurrent checkouts
+  // that both pass the pre-check above before either inserts
+  const { data: newAssignment, error: assignError } = await ctx.admin
+    .from('asset_assignments')
+    .insert({
+      asset_id: assetId,
+      assigned_to_user_id: input.assignedToUserId,
+      assigned_to_name: input.assignedToName,
+      assigned_by: ctx.userId,
+      assigned_by_name: assignedByName,
+      quantity: input.quantity,
+      department_id: input.departmentId || null,
+      location_id: input.locationId || null,
+      expected_return_at: input.expectedReturnAt
+        ? new Date(input.expectedReturnAt).toISOString()
+        : null,
+      notes: input.notes || null,
+    })
+    .select('id')
+    .single()
 
   if (assignError) return { error: assignError.message }
+
+  if (isBulk) {
+    const totalCheckedOut = await fetchCheckedOut(ctx.admin, assetId)
+    if (totalCheckedOut > (asset?.quantity ?? 0)) {
+      await ctx.admin
+        .from('asset_assignments')
+        .delete()
+        .eq('id', (newAssignment as { id: string }).id)
+      return { error: 'This item just went out of stock. Please try again.' }
+    }
+  }
 
   // Bulk assets stay 'active'; only serialized assets become 'checked_out'
   if (!isBulk) {

--- a/src/app/actions/invites.ts
+++ b/src/app/actions/invites.ts
@@ -49,16 +49,21 @@ export async function sendInviteAction(
 
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
 
-  const { error: insertError } = await admin.from('invites').insert({
-    org_id: profile.org_id,
-    email,
-    role,
-    token: crypto.randomUUID(),
-    invited_by: user.id,
-    invited_by_name: profile.full_name,
-    expires_at: expiresAt,
-    department_ids: departmentIds,
-  })
+  // Capture the inserted row's ID so the rollback delete is precise
+  const { data: newInvite, error: insertError } = await admin
+    .from('invites')
+    .insert({
+      org_id: profile.org_id,
+      email,
+      role,
+      token: crypto.randomUUID(),
+      invited_by: user.id,
+      invited_by_name: profile.full_name,
+      expires_at: expiresAt,
+      department_ids: departmentIds,
+    })
+    .select('id')
+    .single()
 
   if (insertError) return { error: insertError.message }
 
@@ -78,8 +83,12 @@ export async function sendInviteAction(
   })
 
   if (authError) {
-    // Roll back the invite row so the user can try again
-    await admin.from('invites').delete().eq('email', email).eq('org_id', profile.org_id)
+    // Roll back using the invite's own ID — precise and safe even if the
+    // email happens to match another pending invite created concurrently
+    await admin
+      .from('invites')
+      .delete()
+      .eq('id', (newInvite as { id: string }).id)
     return { error: authError.message }
   }
 
@@ -134,9 +143,10 @@ export async function acceptInviteAction(
   // Apply pre-assigned departments from the invite
   const deptIds = (invite.department_ids as string[] | null) ?? []
   if (deptIds.length > 0) {
-    await admin
+    const { error: deptError } = await admin
       .from('user_departments')
       .insert(deptIds.map((department_id: string) => ({ user_id: user.id, department_id })))
+    if (deptError) return { error: deptError.message }
   }
 
   // Mark invite accepted


### PR DESCRIPTION
## Problem

Three server actions had correctness issues at their multi-step seams.

**`checkoutAsset` — concurrent oversell of bulk stock**
The availability check (fetch → compute → compare) and the insert were separate steps. Two concurrent checkout requests could both pass the check before either inserted, overselling stock beyond `quantity`.

**`sendInviteAction` — imprecise rollback on email failure**
If Supabase's auth invite email failed, the rollback deleted by `(email, org_id)` rather than the specific row ID. A concurrent invite for the same email could be deleted instead.

**`acceptInviteAction` — silent department assignment failure**
The `user_departments` insert ran without capturing its error. If it failed, the user landed in an active state with no department memberships and no indication anything went wrong.

## Fix

- **`checkoutAsset`**: Insert the assignment first, then re-verify total checked-out against quantity. If a concurrent checkout pushed the total over the limit, the new row is deleted and a "just went out of stock" error is returned. The pre-check is kept as a fast-path UX guard. Added `clients` param for testability.
- **`sendInviteAction`**: Capture the inserted invite row ID via `.select('id').single()` and use it for the rollback delete.
- **`acceptInviteAction`**: Capture and return the department insert error.

## Tests

Adds 5 new tests: unauthenticated checkout, pre-check stock rejection, post-insert rollback with ID verification, successful serialized checkout, and precise invite rollback target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)