### PR TITLE
chore: enable Google OAuth for local dev

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -15,9 +15,24 @@ SUPABASE_SERVICE_ROLE_KEY=
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # ---------------------------------------------------------------
+# Google OAuth (required for local Google sign-in)
+# ---------------------------------------------------------------
+# 1. Create a project at https://console.cloud.google.com
+# 2. APIs & Services → Credentials → Create OAuth 2.0 Client ID (Web application)
+# 3. Add authorized redirect URI: http://localhost:54321/auth/v1/callback
+# 4. Copy the Client ID and Client Secret below
+# ---------------------------------------------------------------
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# ---------------------------------------------------------------
 # Production (Supabase dashboard → Project Settings → API)
 # ---------------------------------------------------------------
 # NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # NEXT_PUBLIC_APP_URL=https://your-app.vercel.app
+#
+# Google OAuth — also add to Supabase dashboard → Authentication → Providers → Google
+# GOOGLE_CLIENT_ID=your-client-id
+# GOOGLE_CLIENT_SECRET=your-client-secret

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -310,6 +310,11 @@ client_id = ""
 secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
 # Overrides the default auth redirectUrl.
 redirect_uri = ""
+
+[auth.external.google]
+enabled = true
+client_id = "env(GOOGLE_CLIENT_ID)"
+secret = "env(GOOGLE_CLIENT_SECRET)"
 # Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
 # or any other third-party OIDC providers.
 url = ""


### PR DESCRIPTION
## Summary

- Adds `[auth.external.google]` to `supabase/config.toml` so the local Supabase stack supports Google sign-in (reads credentials from env vars, nothing hardcoded)
- Updates `.env.local.example` with instructions for getting Google credentials and the correct local redirect URI (`http://localhost:54321/auth/v1/callback`)

## Setup (local)

1. Add to `.env.local`:
   ```
   GOOGLE_CLIENT_ID=your-client-id
   GOOGLE_CLIENT_SECRET=your-client-secret
   ```
2. Restart local Supabase: `pnpm db:start`

Production Google OAuth is already configured in the Supabase dashboard — no changes needed there.

## Related

Part of the Google OAuth feature tracked in #18. Prerequisite for #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)