### PR TITLE
feat: danger zone — leave org, delete org, delete account

### DIFF
--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -4,14 +4,19 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 import { cn } from '@/lib/utils'
-
-const SETTINGS_NAV = [
-  { label: 'Organisation', href: '/settings/org' },
-  { label: 'Profile', href: '/settings/profile' },
-]
+import { useAuth } from '@/providers/AuthProvider'
 
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const { user } = useAuth()
+
+  const hasOrg = !!user?.orgId
+  const canAccessOrgSettings = hasOrg && (user?.role === 'owner' || user?.role === 'admin')
+
+  const nav = [
+    ...(canAccessOrgSettings ? [{ label: 'Organisation', href: '/settings/org' }] : []),
+    ...(hasOrg ? [{ label: 'Profile', href: '/settings/profile' }] : []),
+  ]
 
   return (
     <div className="space-y-6">
@@ -19,22 +24,24 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
         <h1 className="text-foreground text-2xl font-bold tracking-tight">Settings</h1>
       </div>
       <div className="flex flex-col gap-6 md:flex-row">
-        <nav className="flex shrink-0 flex-row gap-1 md:sticky md:top-0 md:w-44 md:flex-col md:self-start">
-          {SETTINGS_NAV.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={cn(
-                'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                pathname === item.href
-                  ? 'bg-muted text-foreground'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/60'
-              )}
-            >
-              {item.label}
-            </Link>
-          ))}
-        </nav>
+        {nav.length > 1 && (
+          <nav className="flex shrink-0 flex-row gap-1 md:sticky md:top-0 md:w-44 md:flex-col md:self-start">
+            {nav.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                  pathname === item.href
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted/60'
+                )}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+        )}
         <div className="min-w-0 flex-1">{children}</div>
       </div>
     </div>

--- a/src/app/(app)/settings/profile/DangerZone.tsx
+++ b/src/app/(app)/settings/profile/DangerZone.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { deleteOrgAction } from '@/app/actions/org'
+import { deleteAccountAction, leaveOrgAction } from '@/app/actions/users'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useAuth } from '@/providers/AuthProvider'
+import { useOrg } from '@/providers/OrgProvider'
+
+// ---------------------------------------------------------------------------
+// Leave org
+// ---------------------------------------------------------------------------
+
+function LeaveOrgDialog() {
+  const { signOut } = useAuth()
+  const [loading, setLoading] = useState(false)
+
+  async function handleLeave() {
+    setLoading(true)
+    const result = await leaveOrgAction()
+    if (result.error) {
+      toast.error(result.error)
+      setLoading(false)
+      return
+    }
+    await signOut()
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          className="border-destructive text-destructive hover:bg-destructive/10"
+        >
+          Leave organisation
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Leave organisation?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You will lose access immediately. Your edits and activity will remain in the system. You
+            can be re-invited by an admin later.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={loading}
+            onClick={handleLeave}
+          >
+            {loading ? 'Leaving…' : 'Leave organisation'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Delete org
+// ---------------------------------------------------------------------------
+
+function DeleteOrgDialog({ orgName }: { orgName: string }) {
+  const { signOut } = useAuth()
+  const [confirm, setConfirm] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  async function handleDelete() {
+    setLoading(true)
+    const result = await deleteOrgAction()
+    if (result.error) {
+      toast.error(result.error)
+      setLoading(false)
+      return
+    }
+    await signOut()
+  }
+
+  return (
+    <AlertDialog onOpenChange={() => setConfirm('')}>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete organisation</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete organisation?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete <strong>{orgName}</strong> and all its data — assets,
+            departments, categories, locations, and activity history. All members will lose access.
+            This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="px-1 pb-2">
+          <p className="text-muted-foreground mb-2 text-sm">
+            Type <strong>{orgName}</strong> to confirm
+          </p>
+          <Input
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            placeholder={orgName}
+          />
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={confirm !== orgName || loading}
+            onClick={handleDelete}
+          >
+            {loading ? 'Deleting…' : 'Delete organisation'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Delete account
+// ---------------------------------------------------------------------------
+
+function DeleteAccountDialog() {
+  const { signOut } = useAuth()
+  const [loading, setLoading] = useState(false)
+
+  async function handleDelete() {
+    setLoading(true)
+    const result = await deleteAccountAction()
+    if (result.error) {
+      toast.error(result.error)
+      setLoading(false)
+      return
+    }
+    await signOut()
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete account</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Your account will be permanently deleted. This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={loading}
+            onClick={handleDelete}
+          >
+            {loading ? 'Deleting…' : 'Delete account'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// DangerZone — selects the right action based on user state
+// ---------------------------------------------------------------------------
+
+export function DangerZone() {
+  const { user } = useAuth()
+  const { org } = useOrg()
+
+  if (!user) return null
+
+  const isOwner = user.role === 'owner'
+  const hasOrg = !!user.orgId
+
+  return (
+    <Card className="border-destructive/40 shadow-sm">
+      <CardHeader>
+        <CardTitle className="text-destructive text-base">Danger zone</CardTitle>
+        <CardDescription>
+          {!hasOrg
+            ? 'Permanently delete your account.'
+            : isOwner
+              ? 'Permanently delete your organisation and all its data.'
+              : 'Leave your current organisation.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!hasOrg && <DeleteAccountDialog />}
+        {hasOrg && isOwner && <DeleteOrgDialog orgName={org?.name ?? ''} />}
+        {hasOrg && !isOwner && <LeaveOrgDialog />}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(app)/settings/profile/page.tsx
+++ b/src/app/(app)/settings/profile/page.tsx
@@ -19,6 +19,8 @@ import { USER_ROLE_CONFIG } from '@/lib/constants'
 import { UpdateProfileSchema, type UpdateProfileInput } from '@/lib/types'
 import { useAuth } from '@/providers/AuthProvider'
 
+import { DangerZone } from './DangerZone'
+
 export default function ProfileSettingsPage() {
   const { user } = useAuth()
 
@@ -70,6 +72,7 @@ export default function ProfileSettingsPage() {
           </Form>
         </CardContent>
       </Card>
+      <DangerZone />
     </div>
   )
 }

--- a/src/app/(app)/settings/profile/page.tsx
+++ b/src/app/(app)/settings/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import Link from 'next/link'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 
@@ -23,6 +24,7 @@ import { DangerZone } from './DangerZone'
 
 export default function ProfileSettingsPage() {
   const { user } = useAuth()
+  const hasOrg = !!user?.orgId
 
   const form = useForm<UpdateProfileInput>({
     resolver: zodResolver(UpdateProfileSchema),
@@ -38,6 +40,20 @@ export default function ProfileSettingsPage() {
 
   return (
     <div className="space-y-6">
+      {!hasOrg && (
+        <Card className="shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-base">Get started</CardTitle>
+            <CardDescription>You are not part of an organisation yet.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link href="/org/new">Continue to org setup</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle className="text-base">Profile</CardTitle>
@@ -63,15 +79,18 @@ export default function ProfileSettingsPage() {
                 <FormLabel>Email</FormLabel>
                 <Input value={user?.email ?? ''} disabled />
               </FormItem>
-              <FormItem>
-                <FormLabel>Role</FormLabel>
-                <Input value={user ? USER_ROLE_CONFIG[user.role].label : ''} disabled />
-              </FormItem>
+              {hasOrg && (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Input value={user ? USER_ROLE_CONFIG[user.role].label : ''} disabled />
+                </FormItem>
+              )}
               <Button type="submit">Save changes</Button>
             </form>
           </Form>
         </CardContent>
       </Card>
+
       <DangerZone />
     </div>
   )

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -138,3 +138,57 @@ export async function updateOrganization(
 
   return { error: null }
 }
+
+// ---------------------------------------------------------------------------
+// deleteOrgAction
+// ---------------------------------------------------------------------------
+
+export async function deleteOrgAction(): Promise<{ error: string } | { error: null }> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const admin = createAdminClient()
+
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('org_id, role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.org_id) return { error: 'No organisation found' }
+  if (profile.role !== 'owner') return { error: 'Only the organisation owner can delete it' }
+
+  const orgId = profile.org_id as string
+
+  // Detach all members first so their accounts survive the org deletion
+  await admin
+    .from('profiles')
+    .update({
+      org_id: null,
+      role: 'viewer',
+      invite_status: 'pending',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('org_id', orgId)
+    .neq('id', user.id)
+
+  // Clear owner's own profile
+  await admin
+    .from('profiles')
+    .update({
+      org_id: null,
+      role: 'viewer',
+      invite_status: 'pending',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', user.id)
+
+  // Delete the org — cascades departments, categories, locations, vendors,
+  // assets, invites, audit_logs, user_departments
+  const { error } = await admin.from('organizations').delete().eq('id', orgId)
+
+  return { error: error?.message ?? null }
+}

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -165,6 +165,76 @@ export async function removeUserAction(
   return { error: null }
 }
 
+// ---------------------------------------------------------------------------
+// leaveOrgAction
+// ---------------------------------------------------------------------------
+
+export async function leaveOrgAction(): Promise<{ error: string } | { error: null }> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const admin = createAdminClient()
+
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('org_id, role')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (!profile?.org_id) return { error: 'You are not in an organisation' }
+  if (profile.role === 'owner')
+    return { error: 'Owners cannot leave — delete the organisation instead' }
+
+  await admin.from('user_departments').delete().eq('user_id', user.id)
+
+  const { error } = await admin
+    .from('profiles')
+    .update({
+      org_id: null,
+      role: 'viewer',
+      invite_status: 'pending',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', user.id)
+
+  return { error: error?.message ?? null }
+}
+
+// ---------------------------------------------------------------------------
+// deleteAccountAction
+// ---------------------------------------------------------------------------
+
+export async function deleteAccountAction(): Promise<{ error: string } | { error: null }> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const admin = createAdminClient()
+
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('org_id')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (profile?.org_id)
+    return { error: 'Leave or delete your organisation before deleting your account' }
+
+  // Deleting the auth user cascades to the profile row
+  const { error } = await admin.auth.admin.deleteUser(user.id)
+
+  return { error: error?.message ?? null }
+}
+
+// ---------------------------------------------------------------------------
+// requestPasswordResetAction
+// ---------------------------------------------------------------------------
+
 export async function requestPasswordResetAction(
   email: string,
   clients?: ActionClients

--- a/src/components/layout/OnboardingShell.tsx
+++ b/src/components/layout/OnboardingShell.tsx
@@ -3,7 +3,9 @@
 import { BoxesIcon, CheckIcon } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { useAuth } from '@/providers/AuthProvider'
 
 const STEPS = [
   { label: 'Create org', path: '/org/new' },
@@ -15,18 +17,22 @@ const STEPS = [
 export function OnboardingShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const currentIndex = STEPS.findIndex((s) => s.path === pathname)
+  const { signOut } = useAuth()
 
   return (
     <div className="bg-background flex min-h-screen flex-col">
       {/* Header */}
-      <header className="border-border bg-card flex h-14 items-center border-b px-6 shadow-xs">
+      <header className="border-border bg-card flex h-14 items-center justify-between border-b px-6 shadow-xs">
         <div className="flex items-center gap-2">
           <div className="bg-primary flex h-7 w-7 items-center justify-center rounded-lg shadow-sm">
             <BoxesIcon className="text-primary-foreground h-4 w-4" />
           </div>
           <span className="text-sm font-semibold">Trackly</span>
+          <span className="text-muted-foreground ml-2 text-xs">Organization Setup</span>
         </div>
-        <span className="text-muted-foreground ml-4 text-xs">Organization Setup</span>
+        <Button variant="ghost" size="sm" onClick={signOut}>
+          Sign out
+        </Button>
       </header>
 
       {/* Stepper */}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -59,12 +59,15 @@ export async function proxy(request: NextRequest) {
   const isAuthCallback = pathname.startsWith('/auth')
   // Invite accept requires a session but must skip the "no org" redirect
   const isInviteAccept = pathname.startsWith('/invite')
+  // Settings are accessible without an org (profile view + delete account)
+  const isSettingsRoute = pathname.startsWith('/settings')
   const isAppRoute =
     !isAuthRoute &&
     !isPublicRoute &&
     !isOnboardingRoute &&
     !isAuthCallback &&
     !isInviteAccept &&
+    !isSettingsRoute &&
     pathname !== '/' &&
     !pathname.startsWith('/_next')
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -73,7 +73,7 @@ export async function proxy(request: NextRequest) {
 
   if (!user) {
     if (isAuthCallback || isPublicRoute) return supabaseResponse
-    if (isAppRoute || isOnboardingRoute || isInviteAccept) {
+    if (isAppRoute || isOnboardingRoute || isInviteAccept || isSettingsRoute) {
       const url = request.nextUrl.clone()
       url.pathname = '/login'
       return NextResponse.redirect(url)


### PR DESCRIPTION
## Summary
- **Leave organisation** (editor/viewer/admin): clears the user's org membership and departments; their edits and audit history remain attributed to their account. Redirects to login on success.
- **Delete organisation** (owner): detaches all members first so their accounts survive, then deletes the org — cascades assets, departments, categories, locations, vendors, invites, and audit logs. Requires typing the org name to confirm.
- **Delete account** (no-org users only): for accidental signups who never joined an org. Deletes the auth user; profile cascades automatically.

All three actions are server-side guarded — role and org state are verified before any mutation. UI lives in a "Danger zone" card at the bottom of Settings → Profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)