### PR TITLE
feat: settings access control, danger zone, onboarding UX, and invite fixes

### DIFF
--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -9,7 +9,8 @@ import { useAuth } from '@/providers/AuthProvider'
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const { user } = useAuth()
-  const canAccessOrgSettings = user?.role === 'owner' || user?.role === 'admin'
+  const hasOrg = !!user?.orgId
+  const canAccessOrgSettings = hasOrg && (user?.role === 'owner' || user?.role === 'admin')
 
   const nav = [
     ...(canAccessOrgSettings ? [{ label: 'Organisation', href: '/settings/org' }] : []),

--- a/src/app/(app)/settings/org/page.tsx
+++ b/src/app/(app)/settings/org/page.tsx
@@ -107,6 +107,7 @@ export default function OrgSettingsPage() {
   useEffect(() => {
     if (user && !isOwner && !isAdmin) router.replace('/settings/profile')
   }, [user, isOwner, isAdmin, router])
+
   const dc = org?.dashboardConfig ?? {}
   const tc = org?.assetTableConfig ?? {}
   const rc = org?.reportConfig ?? {}
@@ -184,6 +185,8 @@ export default function OrgSettingsPage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [org])
+
+  if (!user || (!isOwner && !isAdmin)) return null
 
   async function onSubmit(data: OrgFormInput) {
     const dashboardConfig = {

--- a/src/app/(app)/settings/profile/DangerZone.tsx
+++ b/src/app/(app)/settings/profile/DangerZone.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { deleteOrgAction } from '@/app/actions/org'
+import { deleteAccountAction, leaveOrgAction } from '@/app/actions/users'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useAuth } from '@/providers/AuthProvider'
+import { useOrg } from '@/providers/OrgProvider'
+
+// ---------------------------------------------------------------------------
+// Leave org
+// ---------------------------------------------------------------------------
+
+function LeaveOrgDialog() {
+  const { signOut } = useAuth()
+  const [loading, setLoading] = useState(false)
+
+  async function handleLeave() {
+    setLoading(true)
+    const result = await leaveOrgAction()
+    if (result.error) {
+      toast.error(result.error)
+      setLoading(false)
+      return
+    }
+    await signOut()
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          className="border-destructive text-destructive hover:bg-destructive/10"
+        >
+          Leave organisation
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Leave organisation?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You will lose access immediately. Your edits and activity will remain in the system. You
+            can be re-invited by an admin later.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={loading}
+            onClick={handleLeave}
+          >
+            {loading ? 'Leaving…' : 'Leave organisation'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Delete org
+// ---------------------------------------------------------------------------
+
+function DeleteOrgDialog({ orgName }: { orgName: string }) {
+  const { signOut } = useAuth()
+  const [confirm, setConfirm] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  async function handleDelete() {
+    setLoading(true)
+    const result = await deleteOrgAction()
+    if (result.error) {
+      toast.error(result.error)
+      setLoading(false)
+      return
+    }
+    await signOut()
+  }
+
+  return (
+    <AlertDialog onOpenChange={() => setConfirm('')}>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete organisation</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete organisation?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete <strong>{orgName}</strong> and all its data — assets,
+            departments, categories, locations, and activity history. All members will lose access.
+            This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="px-1 pb-2">
+          <p className="text-muted-foreground mb-2 text-sm">
+            Type <strong>{orgName}</strong> to confirm
+          </p>
+          <Input
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            placeholder={orgName}
+          />
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={confirm !== orgName || loading}
+            onClick={handleDelete}
+          >
+            {loading ? 'Deleting…' : 'Delete organisation'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Delete account
+// ---------------------------------------------------------------------------
+
+function DeleteAccountDialog() {
+  const { signOut } = useAuth()
+  const [loading, setLoading] = useState(false)
+
+  async function handleDelete() {
+    setLoading(true)
+    const result = await deleteAccountAction()
+    if (result.error) {
+      toast.error(result.error)
+      setLoading(false)
+      return
+    }
+    await signOut()
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete account</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Your account will be permanently deleted. This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={loading}
+            onClick={handleDelete}
+          >
+            {loading ? 'Deleting…' : 'Delete account'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// DangerZone — selects the right action based on user state
+// ---------------------------------------------------------------------------
+
+export function DangerZone() {
+  const { user } = useAuth()
+  const { org } = useOrg()
+
+  if (!user) return null
+
+  const isOwner = user.role === 'owner'
+  const hasOrg = !!user.orgId
+
+  return (
+    <Card className="border-destructive/40 shadow-sm">
+      <CardHeader>
+        <CardTitle className="text-destructive text-base">Danger zone</CardTitle>
+        <CardDescription>
+          {!hasOrg
+            ? 'Permanently delete your account.'
+            : isOwner
+              ? 'Permanently delete your organisation and all its data.'
+              : 'Leave your current organisation.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!hasOrg && <DeleteAccountDialog />}
+        {hasOrg && isOwner && <DeleteOrgDialog orgName={org?.name ?? ''} />}
+        {hasOrg && !isOwner && <LeaveOrgDialog />}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(app)/settings/profile/page.tsx
+++ b/src/app/(app)/settings/profile/page.tsx
@@ -19,6 +19,8 @@ import { USER_ROLE_CONFIG } from '@/lib/constants'
 import { UpdateProfileSchema, type UpdateProfileInput } from '@/lib/types'
 import { useAuth } from '@/providers/AuthProvider'
 
+import { DangerZone } from './DangerZone'
+
 export default function ProfileSettingsPage() {
   const { user } = useAuth()
 
@@ -70,6 +72,7 @@ export default function ProfileSettingsPage() {
           </Form>
         </CardContent>
       </Card>
+      <DangerZone />
     </div>
   )
 }

--- a/src/app/(app)/settings/profile/page.tsx
+++ b/src/app/(app)/settings/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import Link from 'next/link'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 
@@ -23,6 +24,7 @@ import { DangerZone } from './DangerZone'
 
 export default function ProfileSettingsPage() {
   const { user } = useAuth()
+  const hasOrg = !!user?.orgId
 
   const form = useForm<UpdateProfileInput>({
     resolver: zodResolver(UpdateProfileSchema),
@@ -38,6 +40,20 @@ export default function ProfileSettingsPage() {
 
   return (
     <div className="space-y-6">
+      {!hasOrg && (
+        <Card className="shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-base">Get started</CardTitle>
+            <CardDescription>You are not part of an organisation yet.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link href="/org/new">Continue to org setup</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
       <Card className="shadow-sm">
         <CardHeader>
           <CardTitle className="text-base">Profile</CardTitle>
@@ -63,15 +79,18 @@ export default function ProfileSettingsPage() {
                 <FormLabel>Email</FormLabel>
                 <Input value={user?.email ?? ''} disabled />
               </FormItem>
-              <FormItem>
-                <FormLabel>Role</FormLabel>
-                <Input value={user ? USER_ROLE_CONFIG[user.role].label : ''} disabled />
-              </FormItem>
+              {hasOrg && (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Input value={user ? USER_ROLE_CONFIG[user.role].label : ''} disabled />
+                </FormItem>
+              )}
               <Button type="submit">Save changes</Button>
             </form>
           </Form>
         </CardContent>
       </Card>
+
       <DangerZone />
     </div>
   )

--- a/src/app/(onboarding)/setup/complete/page.tsx
+++ b/src/app/(onboarding)/setup/complete/page.tsx
@@ -25,11 +25,14 @@ export default function SetupCompletePage() {
   async function handleComplete() {
     setSaving(true)
     const result = await completeOnboardingSetup({ name, slug }, departments, categories)
-    if (result?.error) {
+    if (result.error) {
       toast.error(result.error)
       setSaving(false)
+      return
     }
-    // On success the server action redirects to /dashboard
+    // Full-page navigation flushes the stale AuthProvider profile (orgId=null)
+    // so settings tabs and org-gated UI reflect the newly created org immediately.
+    window.location.assign('/dashboard')
   }
 
   return (

--- a/src/app/actions/__tests__/_helpers.ts
+++ b/src/app/actions/__tests__/_helpers.ts
@@ -50,6 +50,7 @@ export function makeClients(
     supabase: {
       auth: {
         getUser: vi.fn().mockResolvedValue({ data: { user: { id: userId, email } } }),
+        signInWithOtp: vi.fn().mockResolvedValue({ error: null }),
       },
     } as unknown as NonNullable<ActionClients['supabase']>,
     admin: {

--- a/src/app/actions/__tests__/invites.test.ts
+++ b/src/app/actions/__tests__/invites.test.ts
@@ -4,6 +4,12 @@ import { acceptInviteViaGoogleAction, sendInviteAction } from '../invites'
 
 import { makeChain, makeClients } from './_helpers'
 
+// Mock the raw @supabase/supabase-js client used for implicit-flow OTP
+const mockSignInWithOtp = vi.fn().mockResolvedValue({ error: null })
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ auth: { signInWithOtp: mockSignInWithOtp } })),
+}))
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------

--- a/src/app/actions/__tests__/invites.test.ts
+++ b/src/app/actions/__tests__/invites.test.ts
@@ -51,7 +51,9 @@ describe('sendInviteAction', () => {
       })
       // insert.select.single — returns the new invite's ID
       .mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
-    chain.maybeSingle.mockResolvedValueOnce({ data: null })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: null }) // no duplicate invite
+      .mockResolvedValueOnce({ data: null }) // no existing auth user
 
     const result = await sendInviteAction('new@example.com', 'editor', [], clients)
 
@@ -60,21 +62,22 @@ describe('sendInviteAction', () => {
     expect(chain.eq).toHaveBeenCalledWith('id', 'new-invite-001')
   })
 
-  it('keeps invite row and returns success when invitee already has a Google account', async () => {
-    mockInviteUserByEmail.mockResolvedValueOnce({
-      error: { message: 'A user with this email address has already been registered' },
-    })
+  it('keeps invite row and returns success when invitee already has an account', async () => {
     const clients = makeClients(chain, { inviteUserByEmail: mockInviteUserByEmail })
     chain.single
       .mockResolvedValueOnce({
         data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
       })
       .mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
-    chain.maybeSingle.mockResolvedValueOnce({ data: null })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: null }) // no duplicate invite
+      .mockResolvedValueOnce({ data: { id: 'existing-user' } }) // profile exists → use OTP
 
-    const result = await sendInviteAction('google-user@example.com', 'editor', [], clients)
+    const result = await sendInviteAction('existing@example.com', 'editor', [], clients)
 
     expect(result).toEqual({ error: null })
+    // inviteUserByEmail must not be called — we used OTP instead
+    expect(mockInviteUserByEmail).not.toHaveBeenCalled()
     // Must NOT have rolled back the invite row
     expect(chain.delete).not.toHaveBeenCalled()
   })
@@ -87,7 +90,9 @@ describe('sendInviteAction', () => {
       })
       // insert.select.single
       .mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
-    chain.maybeSingle.mockResolvedValueOnce({ data: null })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: null }) // no duplicate invite
+      .mockResolvedValueOnce({ data: null }) // no existing auth user
 
     const result = await sendInviteAction('new@example.com', 'viewer', [], clients)
 

--- a/src/app/actions/invites.ts
+++ b/src/app/actions/invites.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { createClient as createRawClient } from '@supabase/supabase-js'
 import { redirect } from 'next/navigation'
 
 import { createAdminClient } from '@/lib/supabase/admin'
@@ -84,7 +85,16 @@ export async function sendInviteAction(
     .maybeSingle()
 
   if (existingProfile) {
-    const { error: otpError } = await supabase.auth.signInWithOtp({
+    // Use a raw client with implicit flow so the magic link uses hash tokens
+    // (#access_token=…) instead of a PKCE code. signInWithOtp called server-side
+    // would store the PKCE verifier in the admin's browser — useless when a
+    // different person (the invitee) clicks the link in their own browser.
+    const implicitClient = createRawClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { auth: { flowType: 'implicit', persistSession: false } }
+    )
+    const { error: otpError } = await implicitClient.auth.signInWithOtp({
       email,
       options: { emailRedirectTo: redirectTo },
     })

--- a/src/app/actions/invites.ts
+++ b/src/app/actions/invites.ts
@@ -74,6 +74,30 @@ export async function sendInviteAction(
   const next = `/invite/accept?org=${encodeURIComponent(orgName)}`
   const redirectTo = `${appUrl}/auth/callback?next=${encodeURIComponent(next)}`
 
+  // Check if an auth user already exists for this email (e.g. they previously had an org
+  // and deleted it, or left). inviteUserByEmail fails for existing users, so send a magic
+  // link instead — they'll sign in and land on the invite accept page.
+  const { data: existingProfile } = await admin
+    .from('profiles')
+    .select('id')
+    .eq('email', email)
+    .maybeSingle()
+
+  if (existingProfile) {
+    const { error: otpError } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: redirectTo },
+    })
+    if (otpError) {
+      await admin
+        .from('invites')
+        .delete()
+        .eq('id', (newInvite as { id: string }).id)
+      return { error: otpError.message }
+    }
+    return { error: null }
+  }
+
   const { error: authError } = await admin.auth.admin.inviteUserByEmail(email, {
     redirectTo,
     data: {

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -142,3 +142,57 @@ export async function updateOrganization(
 
   return { error: null }
 }
+
+// ---------------------------------------------------------------------------
+// deleteOrgAction
+// ---------------------------------------------------------------------------
+
+export async function deleteOrgAction(): Promise<{ error: string } | { error: null }> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const admin = createAdminClient()
+
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('org_id, role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.org_id) return { error: 'No organisation found' }
+  if (profile.role !== 'owner') return { error: 'Only the organisation owner can delete it' }
+
+  const orgId = profile.org_id as string
+
+  // Detach all members first so their accounts survive the org deletion
+  await admin
+    .from('profiles')
+    .update({
+      org_id: null,
+      role: 'viewer',
+      invite_status: 'pending',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('org_id', orgId)
+    .neq('id', user.id)
+
+  // Clear owner's own profile
+  await admin
+    .from('profiles')
+    .update({
+      org_id: null,
+      role: 'viewer',
+      invite_status: 'pending',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', user.id)
+
+  // Delete the org — cascades departments, categories, locations, vendors,
+  // assets, invites, audit_logs, user_departments
+  const { error } = await admin.from('organizations').delete().eq('id', orgId)
+
+  return { error: error?.message ?? null }
+}

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -27,7 +27,7 @@ export async function completeOnboardingSetup(
   org: { name: string; slug: string },
   departments: string[],
   categories: string[]
-): Promise<{ error: string } | never> {
+): Promise<{ error: string } | { error: null }> {
   const supabase = await createClient()
   const {
     data: { user },
@@ -67,7 +67,8 @@ export async function completeOnboardingSetup(
     await admin.from('categories').insert(categories.map((name) => ({ name, org_id: orgData.id })))
   }
 
-  redirect('/dashboard')
+  // Return success — client will do a full-page navigation to flush stale AuthProvider state
+  return { error: null }
 }
 
 export async function createOrganization(

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -165,6 +165,76 @@ export async function removeUserAction(
   return { error: null }
 }
 
+// ---------------------------------------------------------------------------
+// leaveOrgAction
+// ---------------------------------------------------------------------------
+
+export async function leaveOrgAction(): Promise<{ error: string } | { error: null }> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const admin = createAdminClient()
+
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('org_id, role')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (!profile?.org_id) return { error: 'You are not in an organisation' }
+  if (profile.role === 'owner')
+    return { error: 'Owners cannot leave — delete the organisation instead' }
+
+  await admin.from('user_departments').delete().eq('user_id', user.id)
+
+  const { error } = await admin
+    .from('profiles')
+    .update({
+      org_id: null,
+      role: 'viewer',
+      invite_status: 'pending',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', user.id)
+
+  return { error: error?.message ?? null }
+}
+
+// ---------------------------------------------------------------------------
+// deleteAccountAction
+// ---------------------------------------------------------------------------
+
+export async function deleteAccountAction(): Promise<{ error: string } | { error: null }> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const admin = createAdminClient()
+
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('org_id')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (profile?.org_id)
+    return { error: 'Leave or delete your organisation before deleting your account' }
+
+  // Deleting the auth user cascades to the profile row
+  const { error } = await admin.auth.admin.deleteUser(user.id)
+
+  return { error: error?.message ?? null }
+}
+
+// ---------------------------------------------------------------------------
+// requestPasswordResetAction
+// ---------------------------------------------------------------------------
+
 export async function requestPasswordResetAction(
   email: string,
   clients?: ActionClients

--- a/src/components/dashboard/StatCard.tsx
+++ b/src/components/dashboard/StatCard.tsx
@@ -37,7 +37,7 @@ export function StatCard({
           </p>
         </div>
         <p className="text-foreground mt-2.5 text-2xl font-bold">{value}</p>
-        {description && <p className="text-muted-foreground mt-1 text-xs">{description}</p>}
+        <p className="text-muted-foreground mt-1 text-xs">{description ?? '\u00A0'}</p>
       </CardContent>
     </Card>
   )

--- a/src/components/layout/OnboardingShell.tsx
+++ b/src/components/layout/OnboardingShell.tsx
@@ -1,9 +1,22 @@
 'use client'
 
-import { BoxesIcon, CheckIcon } from 'lucide-react'
+import { BoxesIcon, CheckIcon, LogOut, Settings } from 'lucide-react'
+import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
+import { getInitials } from '@/lib/utils/formatters'
+import { useAuth } from '@/providers/AuthProvider'
 
 const STEPS = [
   { label: 'Create org', path: '/org/new' },
@@ -15,18 +28,51 @@ const STEPS = [
 export function OnboardingShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const currentIndex = STEPS.findIndex((s) => s.path === pathname)
+  const { user, signOut } = useAuth()
 
   return (
     <div className="bg-background flex min-h-screen flex-col">
       {/* Header */}
-      <header className="border-border bg-card flex h-14 items-center border-b px-6 shadow-xs">
+      <header className="border-border bg-card flex h-14 items-center justify-between border-b px-6 shadow-xs">
         <div className="flex items-center gap-2">
           <div className="bg-primary flex h-7 w-7 items-center justify-center rounded-lg shadow-sm">
             <BoxesIcon className="text-primary-foreground h-4 w-4" />
           </div>
           <span className="text-sm font-semibold">Trackly</span>
+          <span className="text-muted-foreground ml-2 text-xs">Organization Setup</span>
         </div>
-        <span className="text-muted-foreground ml-4 text-xs">Organization Setup</span>
+        {user && (
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" asChild className="text-muted-foreground">
+              <Link href="/settings/profile">
+                <Settings className="mr-1.5 h-4 w-4" />
+                Settings
+              </Link>
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="rounded-full">
+                  <Avatar className="h-8 w-8">
+                    <AvatarFallback className="bg-primary/10 text-primary text-xs font-semibold">
+                      {getInitials(user.fullName)}
+                    </AvatarFallback>
+                  </Avatar>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuLabel className="font-normal">
+                  <p className="text-sm font-medium">{user.fullName}</p>
+                  <p className="text-muted-foreground truncate text-xs">{user.email}</p>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={signOut} className="text-destructive">
+                  <LogOut className="mr-2 h-4 w-4" />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
       </header>
 
       {/* Stepper */}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -88,6 +88,7 @@ export function Sidebar({ onNavClick }: SidebarProps) {
   const pathname = usePathname()
   const { user } = useAuth()
   const { org } = useOrg()
+  const hasOrg = !!user?.orgId
   const isAdmin = user ? canManage(user.role) : false
   const visibleManageItems = isAdmin ? buildNavManage(org?.departmentLabel ?? 'Department') : []
 
@@ -106,11 +107,13 @@ export function Sidebar({ onNavClick }: SidebarProps) {
 
       {/* Nav */}
       <ScrollArea className="flex-1 px-3 py-3">
-        <nav className="space-y-1">
-          {NAV_MAIN.map((item) => (
-            <NavLink key={item.href} item={item} pathname={pathname} onNavClick={onNavClick} />
-          ))}
-        </nav>
+        {hasOrg && (
+          <nav className="space-y-1">
+            {NAV_MAIN.map((item) => (
+              <NavLink key={item.href} item={item} pathname={pathname} onNavClick={onNavClick} />
+            ))}
+          </nav>
+        )}
 
         {visibleManageItems.length > 0 && (
           <>
@@ -126,7 +129,9 @@ export function Sidebar({ onNavClick }: SidebarProps) {
           </>
         )}
 
-        <Separator className="bg-sidebar-border my-3" />
+        {(hasOrg || visibleManageItems.length > 0) && (
+          <Separator className="bg-sidebar-border my-3" />
+        )}
         <nav className="space-y-1">
           {NAV_SETTINGS.map((item) => (
             <NavLink key={item.href} item={item} pathname={pathname} onNavClick={onNavClick} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -90,7 +90,9 @@ export function Sidebar({ onNavClick }: SidebarProps) {
   const { org } = useOrg()
   const hasOrg = !!user?.orgId
   const isAdmin = user ? canManage(user.role) : false
-  const visibleManageItems = isAdmin ? buildNavManage(org?.departmentLabel ?? 'Department') : []
+  const isSettingsRoute = pathname.startsWith('/settings')
+  const visibleManageItems =
+    isAdmin && !isSettingsRoute ? buildNavManage(org?.departmentLabel ?? 'Department') : []
 
   return (
     <div className="bg-sidebar flex h-full flex-col">
@@ -107,7 +109,7 @@ export function Sidebar({ onNavClick }: SidebarProps) {
 
       {/* Nav */}
       <ScrollArea className="flex-1 px-3 py-3">
-        {hasOrg && (
+        {hasOrg && !isSettingsRoute && (
           <nav className="space-y-1">
             {NAV_MAIN.map((item) => (
               <NavLink key={item.href} item={item} pathname={pathname} onNavClick={onNavClick} />
@@ -129,9 +131,9 @@ export function Sidebar({ onNavClick }: SidebarProps) {
           </>
         )}
 
-        {(hasOrg || visibleManageItems.length > 0) && (
+        {(hasOrg && !isSettingsRoute) || visibleManageItems.length > 0 ? (
           <Separator className="bg-sidebar-border my-3" />
-        )}
+        ) : null}
         <nav className="space-y-1">
           {NAV_SETTINGS.map((item) => (
             <NavLink key={item.href} item={item} pathname={pathname} onNavClick={onNavClick} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -109,7 +109,7 @@ export function Sidebar({ onNavClick }: SidebarProps) {
 
       {/* Nav */}
       <ScrollArea className="flex-1 px-3 py-3">
-        {hasOrg && !isSettingsRoute && (
+        {hasOrg && (
           <nav className="space-y-1">
             {NAV_MAIN.map((item) => (
               <NavLink key={item.href} item={item} pathname={pathname} onNavClick={onNavClick} />
@@ -131,9 +131,9 @@ export function Sidebar({ onNavClick }: SidebarProps) {
           </>
         )}
 
-        {(hasOrg && !isSettingsRoute) || visibleManageItems.length > 0 ? (
+        {(hasOrg || visibleManageItems.length > 0) && (
           <Separator className="bg-sidebar-border my-3" />
-        ) : null}
+        )}
         <nav className="space-y-1">
           {NAV_SETTINGS.map((item) => (
             <NavLink key={item.href} item={item} pathname={pathname} onNavClick={onNavClick} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -90,9 +90,7 @@ export function Sidebar({ onNavClick }: SidebarProps) {
   const { org } = useOrg()
   const hasOrg = !!user?.orgId
   const isAdmin = user ? canManage(user.role) : false
-  const isSettingsRoute = pathname.startsWith('/settings')
-  const visibleManageItems =
-    isAdmin && !isSettingsRoute ? buildNavManage(org?.departmentLabel ?? 'Department') : []
+  const visibleManageItems = isAdmin ? buildNavManage(org?.departmentLabel ?? 'Department') : []
 
   return (
     <div className="bg-sidebar flex h-full flex-col">

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -59,12 +59,15 @@ export async function proxy(request: NextRequest) {
   const isAuthCallback = pathname.startsWith('/auth')
   // Invite accept requires a session but must skip the "no org" redirect
   const isInviteAccept = pathname.startsWith('/invite')
+  // Settings are accessible without an org (profile view + delete account)
+  const isSettingsRoute = pathname.startsWith('/settings')
   const isAppRoute =
     !isAuthRoute &&
     !isPublicRoute &&
     !isOnboardingRoute &&
     !isAuthCallback &&
     !isInviteAccept &&
+    !isSettingsRoute &&
     pathname !== '/' &&
     !pathname.startsWith('/_next')
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -73,7 +73,7 @@ export async function proxy(request: NextRequest) {
 
   if (!user) {
     if (isAuthCallback || isPublicRoute) return supabaseResponse
-    if (isAppRoute || isOnboardingRoute || isInviteAccept) {
+    if (isAppRoute || isOnboardingRoute || isInviteAccept || isSettingsRoute) {
       const url = request.nextUrl.clone()
       url.pathname = '/login'
       return NextResponse.redirect(url)

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -238,6 +238,10 @@ content_path = "./supabase/templates/recovery.html"
 subject = "Confirm your Trackly email"
 content_path = "./supabase/templates/confirmation.html"
 
+[auth.email.template.magic_link]
+subject = "Your Trackly sign-in link"
+content_path = "./supabase/templates/magic_link.html"
+
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.
 enable_signup = false

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your Trackly sign-in link</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F0EFEC;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F0EFEC;padding:40px 16px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:520px;">
+
+          <!-- Logo -->
+          <tr>
+            <td align="center" style="padding-bottom:24px;">
+              <table cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td style="background-color:#5C5FEF;border-radius:12px;padding:10px 14px;">
+                    <span style="color:#ffffff;font-size:18px;font-weight:700;letter-spacing:-0.3px;">Trackly</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Card -->
+          <tr>
+            <td style="background-color:#ffffff;border-radius:16px;border:1px solid #E0DDD8;padding:40px 40px 36px;">
+
+              <p style="margin:0 0 8px;font-size:13px;font-weight:600;color:#5C5FEF;text-transform:uppercase;letter-spacing:0.8px;">You're invited</p>
+              <h1 style="margin:0 0 16px;font-size:24px;font-weight:700;color:#1E2847;line-height:1.3;">
+                Sign in to accept your invitation
+              </h1>
+              <p style="margin:0 0 28px;font-size:15px;color:#616C82;line-height:1.6;">
+                You've been invited to join an organisation on Trackly. Click the button below to sign in to your existing account (<strong style="color:#1E2847;">{{ .Email }}</strong>) and accept the invitation.
+              </p>
+
+              <!-- CTA Button -->
+              <table cellpadding="0" cellspacing="0" border="0" style="margin-bottom:28px;">
+                <tr>
+                  <td style="background-color:#5C5FEF;border-radius:10px;">
+                    <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:13px 28px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;letter-spacing:-0.1px;">
+                      Sign in and accept →
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Divider -->
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:20px;">
+                <tr>
+                  <td style="border-top:1px solid #E0DDD8;"></td>
+                </tr>
+              </table>
+
+              <p style="margin:0 0 4px;font-size:13px;color:#9CA3AF;">This link expires in 1 hour. If you didn't expect this, you can safely ignore it — your account won't be affected.</p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td align="center" style="padding-top:24px;">
+              <p style="margin:0;font-size:12px;color:#9CA3AF;">
+                Trackly · Asset management for teams
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Settings access control**: Viewers/editors redirected away from `/settings/org`; manage section hidden in sidebar for non-admins and no-org users; settings inner nav always shows Profile tab
- **Danger zone**: Leave org (members), delete org (owners with type-to-confirm), delete account (no-org users only)
- **Onboarding UX**: Settings link + sign-out dropdown in OnboardingShell header; full-page reload after org creation so AuthProvider picks up new `orgId` immediately
- **Invite fallback for existing users**: When inviting an email that already has an account, fall back to a magic link (implicit flow, not PKCE) so the link works in the invitee's browser
- **Magic link email template**: New `supabase/templates/magic_link.html` matching existing template style
- **Dashboard stat cards**: Consistent height regardless of whether a percentage description is shown
- **Proxy**: No-org users can access `/settings` without being bounced to `/org/new`

## Test plan

- [ ] Owner/admin: can access `/settings/org`, sees Organisation + Profile tabs
- [ ] Viewer/editor: redirected to `/settings/profile`, sees only Profile tab
- [ ] No-org user: can access `/settings/profile`, sees "Continue to org setup" CTA, no main nav or manage section in sidebar
- [ ] Danger zone — leave org: member can leave, owner cannot
- [ ] Danger zone — delete org: owner types org name to confirm, members detached, owner signed out after deletion
- [ ] Danger zone — delete account: only available when user has no org
- [ ] Completing onboarding redirects to dashboard with correct nav tabs visible immediately
- [ ] Inviting an existing-account email sends a magic link that works (no `invalid_link` error)
- [ ] Dashboard stat cards are uniform height

🤖 Generated with [Claude Code](https://claude.com/claude-code)