### PR TITLE
feat: permission policy with action vocabulary

### DIFF
--- a/src/app/actions/_context.ts
+++ b/src/app/actions/_context.ts
@@ -1,7 +1,7 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import type { UserRole } from '@/lib/types'
-import { canEdit, canEditInDepartment, canManage } from '@/lib/utils/permissions'
+import { canEdit, canManage } from '@/lib/utils/permissions'
 
 export type ActionContext = {
   userId: string
@@ -54,13 +54,4 @@ export async function getAdminCtx(): Promise<ActionContext | { error: string }> 
   const ctx = await getContext()
   if (!ctx) return { error: 'Not authenticated' }
   return ctx.requireRole('admin') ?? ctx
-}
-
-export function requireCanEdit(
-  ctx: ActionContext,
-  assetDepartmentId: string | null
-): { error: string } | null {
-  return canEditInDepartment(ctx.role, ctx.departmentIds, assetDepartmentId)
-    ? null
-    : { error: 'Not authorised' }
 }

--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 
+import { createPolicy } from '@/lib/permissions'
 import {
   AssetFormSchema,
   CheckoutFormSchema,
@@ -14,7 +15,7 @@ import { computeAvailable } from '@/lib/utils/availability'
 
 import { logAudit } from './_audit'
 import type { ActionClients, ActionContext } from './_context'
-import { getContext, requireCanEdit } from './_context'
+import { getContext } from './_context'
 
 // ---------------------------------------------------------------------------
 // Private helpers
@@ -46,7 +47,7 @@ export async function createAsset(
   const ctx = await getContext(clients)
   if (!ctx) return { error: 'Not authenticated' }
 
-  const denied = requireCanEdit(ctx, input.departmentId ?? null)
+  const denied = createPolicy(ctx).enforce('asset:create', input.departmentId ?? null)
   if (denied) return denied
 
   const { data, error } = await ctx.admin
@@ -105,7 +106,10 @@ export async function updateAsset(
     .eq('id', id)
     .maybeSingle()
 
-  const denied = requireCanEdit(ctx, (old?.department_id as string | null) ?? null)
+  const denied = createPolicy(ctx).enforce(
+    'asset:update',
+    (old?.department_id as string | null) ?? null
+  )
   if (denied) return denied
 
   const { error } = await ctx.admin
@@ -167,7 +171,10 @@ export async function deleteAsset(
     .eq('id', id)
     .maybeSingle()
 
-  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  const denied = createPolicy(ctx).enforce(
+    'asset:delete',
+    (asset?.department_id as string | null) ?? null
+  )
   if (denied) return denied
 
   const { error } = await ctx.admin
@@ -209,7 +216,10 @@ export async function checkoutAsset(
     .eq('id', assetId)
     .single()
 
-  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  const denied = createPolicy(ctx).enforce(
+    'asset:checkout',
+    (asset?.department_id as string | null) ?? null
+  )
   if (denied) return denied
 
   // Fast-path: reject immediately if obviously out of stock
@@ -297,7 +307,10 @@ export async function returnAsset(assetId: string): Promise<{ error: string } | 
     .eq('id', assetId)
     .maybeSingle()
 
-  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  const denied = createPolicy(ctx).enforce(
+    'asset:return',
+    (asset?.department_id as string | null) ?? null
+  )
   if (denied) return denied
 
   const { error: assignError } = await ctx.admin
@@ -352,7 +365,7 @@ export async function returnBulkAssignment(
   const assetDeptId =
     (Array.isArray(assetJoin) ? assetJoin[0]?.department_id : assetJoin?.department_id) ?? null
 
-  const denied = requireCanEdit(ctx, assetDeptId)
+  const denied = createPolicy(ctx).enforce('asset:return', assetDeptId)
   if (denied) return denied
 
   const remaining = (row.quantity as number) - quantityToReturn
@@ -402,7 +415,10 @@ export async function restockAsset(
     .eq('id', assetId)
     .single()
 
-  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  const denied = createPolicy(ctx).enforce(
+    'asset:restock',
+    (asset?.department_id as string | null) ?? null
+  )
   if (denied) return denied
 
   const oldQuantity = (asset?.quantity ?? 0) as number
@@ -448,7 +464,10 @@ export async function updateAssignment(
     .eq('id', assetId)
     .maybeSingle()
 
-  const denied = requireCanEdit(ctx, (asset?.department_id as string | null) ?? null)
+  const denied = createPolicy(ctx).enforce(
+    'assignment:update',
+    (asset?.department_id as string | null) ?? null
+  )
   if (denied) return denied
 
   if (isBulk) {

--- a/src/lib/hooks/useAssets.ts
+++ b/src/lib/hooks/useAssets.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 
 import { getNextTagForPrefix } from '@/app/actions/assets'
 import { ASSET_TAG_PREFIX } from '@/lib/constants'
+import { applyDepartmentConstraint, createPolicy } from '@/lib/permissions'
 import { createClient } from '@/lib/supabase/client'
 import type {
   AssetAssignment,
@@ -13,7 +14,6 @@ import type {
 } from '@/lib/types'
 import { ASSET_STATUS_LABELS } from '@/lib/types/asset'
 import { computeAvailable } from '@/lib/utils/availability'
-import { canManage } from '@/lib/utils/permissions'
 import { useAuth } from '@/providers/AuthProvider'
 
 export type AssetFilters = {
@@ -201,13 +201,7 @@ export function useAssets(filters: AssetFilters = {}, page = 1, pageSize = 25): 
       if (filters.departmentId) query = query.eq('department_id', filters.departmentId)
       if (filters.categoryId) query = query.eq('category_id', filters.categoryId)
 
-      if (!canManage(user!.role)) {
-        if (user!.departmentIds.length > 0) {
-          query = query.in('department_id', user!.departmentIds)
-        } else {
-          query = query.eq('department_id', '00000000-0000-0000-0000-000000000000')
-        }
-      }
+      query = applyDepartmentConstraint(query, createPolicy(user!).queryConstraint())
 
       const from = (page - 1) * pageSize
       const to = from + pageSize - 1

--- a/src/lib/permissions/__tests__/policy.test.ts
+++ b/src/lib/permissions/__tests__/policy.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import { createPolicy } from '../policy'
+
+const DEPT_A = 'dept-aaaa-0000'
+const DEPT_B = 'dept-bbbb-1111'
+
+// ---------------------------------------------------------------------------
+// enforce
+// ---------------------------------------------------------------------------
+
+describe('enforce — role gate', () => {
+  it('allows owner for any action', () => {
+    const policy = createPolicy({ role: 'owner', departmentIds: [] })
+    expect(policy.enforce('asset:create', null)).toBeNull()
+    expect(policy.enforce('org:manage')).toBeNull()
+  })
+
+  it('allows admin for editor-level and admin-level actions', () => {
+    const policy = createPolicy({ role: 'admin', departmentIds: [] })
+    expect(policy.enforce('asset:update', DEPT_A)).toBeNull()
+    expect(policy.enforce('department:manage')).toBeNull()
+  })
+
+  it('denies admin for owner-only actions', () => {
+    const policy = createPolicy({ role: 'admin', departmentIds: [] })
+    expect(policy.enforce('org:manage')).toEqual({ error: 'Not authorised' })
+  })
+
+  it('denies viewer for editor-level actions', () => {
+    const policy = createPolicy({ role: 'viewer', departmentIds: [DEPT_A] })
+    expect(policy.enforce('asset:create', DEPT_A)).toEqual({ error: 'Not authorised' })
+  })
+
+  it('denies viewer for admin-level actions', () => {
+    const policy = createPolicy({ role: 'viewer', departmentIds: [] })
+    expect(policy.enforce('department:manage')).toEqual({ error: 'Not authorised' })
+  })
+})
+
+describe('enforce — department scope for editors', () => {
+  it('allows editor in their assigned department', () => {
+    const policy = createPolicy({ role: 'editor', departmentIds: [DEPT_A] })
+    expect(policy.enforce('asset:update', DEPT_A)).toBeNull()
+  })
+
+  it('denies editor outside their departments', () => {
+    const policy = createPolicy({ role: 'editor', departmentIds: [DEPT_B] })
+    expect(policy.enforce('asset:update', DEPT_A)).toEqual({ error: 'Not authorised' })
+  })
+
+  it('denies editor when asset has no department', () => {
+    const policy = createPolicy({ role: 'editor', departmentIds: [DEPT_A] })
+    expect(policy.enforce('asset:update', null)).toEqual({ error: 'Not authorised' })
+  })
+
+  it('allows owner regardless of department', () => {
+    const policy = createPolicy({ role: 'owner', departmentIds: [] })
+    expect(policy.enforce('asset:delete', null)).toBeNull()
+    expect(policy.enforce('asset:delete', DEPT_A)).toBeNull()
+  })
+
+  it('allows admin regardless of department', () => {
+    const policy = createPolicy({ role: 'admin', departmentIds: [] })
+    expect(policy.enforce('asset:checkout', DEPT_A)).toBeNull()
+  })
+})
+
+describe('enforce — all asset actions use the same dept-scoped rule', () => {
+  const editor = createPolicy({ role: 'editor', departmentIds: [DEPT_A] })
+
+  it.each([
+    'asset:create',
+    'asset:update',
+    'asset:delete',
+    'asset:checkout',
+    'asset:return',
+    'asset:restock',
+    'assignment:update',
+  ] as const)('%s allows editor in dept', (action) => {
+    expect(editor.enforce(action, DEPT_A)).toBeNull()
+  })
+
+  it.each([
+    'asset:create',
+    'asset:update',
+    'asset:delete',
+    'asset:checkout',
+    'asset:return',
+    'asset:restock',
+    'assignment:update',
+  ] as const)('%s denies editor outside dept', (action) => {
+    expect(editor.enforce(action, DEPT_B)).toEqual({ error: 'Not authorised' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// queryConstraint
+// ---------------------------------------------------------------------------
+
+describe('queryConstraint', () => {
+  it('returns all for owner', () => {
+    const policy = createPolicy({ role: 'owner', departmentIds: [] })
+    expect(policy.queryConstraint()).toEqual({ kind: 'all' })
+  })
+
+  it('returns all for admin', () => {
+    const policy = createPolicy({ role: 'admin', departmentIds: [DEPT_A] })
+    expect(policy.queryConstraint()).toEqual({ kind: 'all' })
+  })
+
+  it('returns in for editor with departments', () => {
+    const policy = createPolicy({ role: 'editor', departmentIds: [DEPT_A, DEPT_B] })
+    expect(policy.queryConstraint()).toEqual({ kind: 'in', ids: [DEPT_A, DEPT_B] })
+  })
+
+  it('returns none for editor with no departments', () => {
+    const policy = createPolicy({ role: 'editor', departmentIds: [] })
+    expect(policy.queryConstraint()).toEqual({ kind: 'none' })
+  })
+
+  it('returns in for viewer with departments', () => {
+    const policy = createPolicy({ role: 'viewer', departmentIds: [DEPT_A] })
+    expect(policy.queryConstraint()).toEqual({ kind: 'in', ids: [DEPT_A] })
+  })
+
+  it('returns none for viewer with no departments', () => {
+    const policy = createPolicy({ role: 'viewer', departmentIds: [] })
+    expect(policy.queryConstraint()).toEqual({ kind: 'none' })
+  })
+})

--- a/src/lib/permissions/index.ts
+++ b/src/lib/permissions/index.ts
@@ -1,0 +1,3 @@
+export { createPolicy } from './policy'
+export type { DepartmentConstraint, PermissionPrincipal, PolicyAction } from './policy'
+export { applyDepartmentConstraint } from './supabase'

--- a/src/lib/permissions/policy.ts
+++ b/src/lib/permissions/policy.ts
@@ -1,0 +1,88 @@
+import type { UserRole } from '@/lib/types'
+
+export type PolicyAction =
+  | 'asset:create'
+  | 'asset:update'
+  | 'asset:delete'
+  | 'asset:checkout'
+  | 'asset:return'
+  | 'asset:restock'
+  | 'assignment:update'
+  | 'department:manage'
+  | 'user:manage'
+  | 'org:manage'
+
+export type DepartmentConstraint =
+  | { kind: 'all' }
+  | { kind: 'in'; ids: string[] }
+  | { kind: 'none' }
+
+export type PermissionPrincipal = {
+  role: UserRole
+  departmentIds: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+const ROLE_HIERARCHY: UserRole[] = ['viewer', 'editor', 'admin', 'owner']
+
+const ACTION_RULES: Record<
+  PolicyAction,
+  { minRole: 'editor' | 'admin' | 'owner'; deptScoped: boolean }
+> = {
+  'asset:create': { minRole: 'editor', deptScoped: true },
+  'asset:update': { minRole: 'editor', deptScoped: true },
+  'asset:delete': { minRole: 'editor', deptScoped: true },
+  'asset:checkout': { minRole: 'editor', deptScoped: true },
+  'asset:return': { minRole: 'editor', deptScoped: true },
+  'asset:restock': { minRole: 'editor', deptScoped: true },
+  'assignment:update': { minRole: 'editor', deptScoped: true },
+  'department:manage': { minRole: 'admin', deptScoped: false },
+  'user:manage': { minRole: 'admin', deptScoped: false },
+  'org:manage': { minRole: 'owner', deptScoped: false },
+}
+
+function meetsMinRole(role: UserRole, minRole: 'editor' | 'admin' | 'owner'): boolean {
+  return ROLE_HIERARCHY.indexOf(role) >= ROLE_HIERARCHY.indexOf(minRole)
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createPolicy(principal: PermissionPrincipal) {
+  const { role, departmentIds } = principal
+
+  return {
+    /**
+     * Gate check for a single operation. Returns null on success or
+     * { error } on denial — same shape as every server action return type.
+     *
+     * @example
+     *   const denied = createPolicy(ctx).enforce('asset:update', asset.department_id)
+     *   if (denied) return denied
+     */
+    enforce(action: PolicyAction, departmentId?: string | null): { error: string } | null {
+      const rule = ACTION_RULES[action]
+      if (!meetsMinRole(role, rule.minRole)) return { error: 'Not authorised' }
+      if (rule.deptScoped && role !== 'owner' && role !== 'admin') {
+        if (!departmentId || !departmentIds.includes(departmentId)) {
+          return { error: 'Not authorised' }
+        }
+      }
+      return null
+    },
+
+    /**
+     * Returns the constraint that must be applied to any asset collection query.
+     * Pass the result to applyDepartmentConstraint() from @/lib/permissions/supabase.
+     */
+    queryConstraint(): DepartmentConstraint {
+      if (role === 'owner' || role === 'admin') return { kind: 'all' }
+      if (departmentIds.length > 0) return { kind: 'in', ids: departmentIds }
+      return { kind: 'none' }
+    },
+  }
+}

--- a/src/lib/permissions/supabase.ts
+++ b/src/lib/permissions/supabase.ts
@@ -1,0 +1,19 @@
+import type { DepartmentConstraint } from './policy'
+
+// Supabase's .in(col, []) returns all rows instead of none, so we use an
+// impossible UUID to force a zero-result query when an editor has no departments.
+const IMPOSSIBLE_UUID = '00000000-0000-0000-0000-000000000000'
+
+type FilterableQuery = {
+  in(column: string, values: string[]): FilterableQuery
+  eq(column: string, value: string): FilterableQuery
+}
+
+export function applyDepartmentConstraint<Q extends FilterableQuery>(
+  query: Q,
+  constraint: DepartmentConstraint
+): Q {
+  if (constraint.kind === 'in') return query.in('department_id', constraint.ids) as Q
+  if (constraint.kind === 'none') return query.eq('department_id', IMPOSSIBLE_UUID) as Q
+  return query // 'all' — owner/admin, no filter needed
+}


### PR DESCRIPTION
## Problem

Authorization was expressed in two incompatible forms with no shared contract:

- **Client** (`useAssets.ts`): a 6-line manual block calling `canManage()` and appending `.in('department_id', ...)` to the Supabase query — including a sentinel-UUID workaround for Supabase's `.in(col, [])` behavior
- **Server** (`_context.ts` + `assets.ts`): a free function `requireCanEdit(ctx, deptId)` called 8× across every asset mutation

The rule ("editors can only touch assets in their departments") lived in two places. A new hook that forgot the `.in(...)` filter silently leaked data to unauthorized users. A new action that forgot `requireCanEdit` silently allowed unauthorized writes. No test spanned both enforcement points.

## Solution

New `src/lib/permissions/` module with two exports callers need:

**`createPolicy(principal).enforce(action, departmentId)`** — server action gate

```ts
// before
const denied = requireCanEdit(ctx, asset.department_id)

// after — action is named, rule table decides what it requires
const denied = createPolicy(ctx).enforce('asset:checkout', asset.department_id)
```

**`applyDepartmentConstraint(query, createPolicy(user).queryConstraint())`** — client query filter

```ts
// before — 6 lines, sentinel UUID inline
if (!canManage(user.role)) {
  if (user.departmentIds.length > 0) {
    query = query.in('department_id', user.departmentIds)
  } else {
    query = query.eq('department_id', '00000000-0000-0000-0000-000000000000')
  }
}

// after — one line, sentinel UUID lives in supabase.ts
query = applyDepartmentConstraint(query, createPolicy(user).queryConstraint())
```

## Action vocabulary

`PolicyAction` is a closed string union backed by `ACTION_RULES` — a table mapping each action to its minimum role and whether it's department-scoped:

```ts
'asset:create'      → editor, dept-scoped
'asset:update'      → editor, dept-scoped
'asset:delete'      → editor, dept-scoped
'asset:checkout'    → editor, dept-scoped
'asset:return'      → editor, dept-scoped
'asset:restock'     → editor, dept-scoped
'assignment:update' → editor, dept-scoped
'department:manage' → admin,  not scoped
'user:manage'       → admin,  not scoped
'org:manage'        → owner,  not scoped
```

When a per-action rule change arrives (e.g. "viewers can return their own assignments"), it's a one-line table edit — not a callsite hunt.

## Files changed

| File | Change |
|---|---|
| `src/lib/permissions/policy.ts` | New — `createPolicy` factory, `PolicyAction` union, `ACTION_RULES` table |
| `src/lib/permissions/supabase.ts` | New — `applyDepartmentConstraint` (owns sentinel UUID) |
| `src/lib/permissions/index.ts` | New — public re-exports |
| `src/lib/permissions/__tests__/policy.test.ts` | New — 26 boundary tests for `enforce` + `queryConstraint` across all roles/actions/edge cases |
| `src/app/actions/_context.ts` | Removed `requireCanEdit` and `canEditInDepartment` import |
| `src/app/actions/assets.ts` | 8× `requireCanEdit(ctx, ...)` → `createPolicy(ctx).enforce(action, deptId)` |
| `src/lib/hooks/useAssets.ts` | 6-line filter block → `applyDepartmentConstraint(query, createPolicy(user).queryConstraint())` |

## Test plan

- [x] All 150 existing tests pass
- [x] 26 new boundary tests covering: role gate (all roles × admin/owner-only actions), dept-scope (editor in dept, editor outside dept, editor with null dept, owner/admin bypass), `queryConstraint` (all 6 role × dept combinations), all 7 dept-scoped actions
- [x] TypeScript strict — no type errors (`tsc --noEmit` clean)
- [x] Linter + formatter clean (pre-commit hook passed)

## Future-proofing note

The `PermissionPrincipal` type (`{ role, departmentIds }`) is intentionally minimal. When multi-org support arrives, `createPolicy` can accept a per-org membership shape without touching any call site — callers just construct the principal differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)