### PR TITLE
feat: centralize cache invalidation in a single dependency graph

### DIFF
--- a/src/lib/hooks/__tests__/queryInvalidation.test.ts
+++ b/src/lib/hooks/__tests__/queryInvalidation.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { invalidateForTable } from '../queryInvalidation'
+
+const ORG = 'org-0001'
+
+function makeClient() {
+  const calls: readonly unknown[][] = []
+  return {
+    invalidateQueries: vi.fn(({ queryKey }: { queryKey: readonly unknown[] }) => {
+      ;(calls as unknown as (readonly unknown[])[]).push(queryKey)
+      return Promise.resolve()
+    }),
+    _calls: calls,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Assets
+// ---------------------------------------------------------------------------
+
+describe('assets table', () => {
+  it('invalidates list, single, and dashboard', () => {
+    const qc = makeClient()
+    invalidateForTable(qc as never, ORG, 'assets')
+    expect(qc._calls).toContainEqual(['assets'])
+    expect(qc._calls).toContainEqual(['asset'])
+    expect(qc._calls).toContainEqual(['dashboardStats', ORG])
+  })
+})
+
+describe('asset_assignments table', () => {
+  it('invalidates list, single, and dashboard', () => {
+    const qc = makeClient()
+    invalidateForTable(qc as never, ORG, 'asset_assignments')
+    expect(qc._calls).toContainEqual(['assets'])
+    expect(qc._calls).toContainEqual(['asset'])
+    expect(qc._calls).toContainEqual(['dashboardStats', ORG])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Reference-data tables (categories, departments, locations, vendors)
+// ---------------------------------------------------------------------------
+
+describe.each(['categories', 'departments', 'locations', 'vendors'] as const)(
+  '%s table',
+  (table) => {
+    it('invalidates its own list key', () => {
+      const qc = makeClient()
+      invalidateForTable(qc as never, ORG, table)
+      expect(qc._calls).toContainEqual([table, ORG])
+    })
+
+    it('invalidates asset list and single (denormalized names)', () => {
+      const qc = makeClient()
+      invalidateForTable(qc as never, ORG, table)
+      expect(qc._calls).toContainEqual(['assets'])
+      expect(qc._calls).toContainEqual(['asset'])
+    })
+
+    it('invalidates dashboard (breakdown stats)', () => {
+      const qc = makeClient()
+      invalidateForTable(qc as never, ORG, table)
+      expect(qc._calls).toContainEqual(['dashboardStats', ORG])
+    })
+  }
+)
+
+// ---------------------------------------------------------------------------
+// Audit logs
+// ---------------------------------------------------------------------------
+
+describe('audit_logs table', () => {
+  it('invalidates recentActivity scoped to orgId (not bare prefix)', () => {
+    const qc = makeClient()
+    invalidateForTable(qc as never, ORG, 'audit_logs')
+    expect(qc._calls).toContainEqual(['recentActivity', ORG])
+    expect(qc._calls).not.toContainEqual(['recentActivity']) // bare prefix is wrong
+  })
+
+  it('invalidates assetHistory (prefix — no assetId available from table event)', () => {
+    const qc = makeClient()
+    invalidateForTable(qc as never, ORG, 'audit_logs')
+    expect(qc._calls).toContainEqual(['assetHistory'])
+  })
+
+  it('invalidates dashboard (7-day activity count)', () => {
+    const qc = makeClient()
+    invalidateForTable(qc as never, ORG, 'audit_logs')
+    expect(qc._calls).toContainEqual(['dashboardStats', ORG])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// User/invite tables
+// ---------------------------------------------------------------------------
+
+describe.each(['profiles', 'invites', 'user_departments'] as const)('%s table', (table) => {
+  it('invalidates orgUsers scoped to orgId', () => {
+    const qc = makeClient()
+    invalidateForTable(qc as never, ORG, table)
+    expect(qc._calls).toContainEqual(['orgUsers', ORG])
+  })
+
+  it('does not invalidate assets', () => {
+    const qc = makeClient()
+    invalidateForTable(qc as never, ORG, table)
+    expect(qc._calls).not.toContainEqual(['assets'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cross-org isolation
+// ---------------------------------------------------------------------------
+
+describe('orgId scoping', () => {
+  it('uses the provided orgId, not a neighbour org', () => {
+    const qc = makeClient()
+    invalidateForTable(qc as never, 'org-A', 'categories')
+    expect(qc._calls).toContainEqual(['categories', 'org-A'])
+    expect(qc._calls).not.toContainEqual(['categories', 'org-B'])
+  })
+})

--- a/src/lib/hooks/makeEntityHooks.ts
+++ b/src/lib/hooks/makeEntityHooks.ts
@@ -16,7 +16,7 @@ export type EntityHookConfig<TEntity, TFormInput> = {
     update: (id: string, input: TFormInput) => Promise<{ error: string } | null>
     delete: (id: string) => Promise<{ error: string } | null>
   }
-  onDeleteSuccess?: (queryClient: ReturnType<typeof useQueryClient>) => void
+  onDeleteSuccess?: (queryClient: ReturnType<typeof useQueryClient>, orgId: string) => void
 }
 
 export function makeEntityHooks<TEntity, TFormInput>(
@@ -93,7 +93,7 @@ export function makeEntityHooks<TEntity, TFormInput>(
       onSuccess: () => {
         toast.success(`${label} deleted`)
         invalidate()
-        onDeleteSuccess?.(queryClient)
+        onDeleteSuccess?.(queryClient, orgId)
       },
       onError: (err: Error) => toast.error(err.message),
     })

--- a/src/lib/hooks/queryInvalidation.ts
+++ b/src/lib/hooks/queryInvalidation.ts
@@ -1,0 +1,85 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+/**
+ * Every DB table the app subscribes to or mutates.
+ * Used as the key into the dependency graph below.
+ */
+export type AppTable =
+  | 'assets'
+  | 'asset_assignments'
+  | 'audit_logs'
+  | 'categories'
+  | 'departments'
+  | 'locations'
+  | 'vendors'
+  | 'profiles'
+  | 'invites'
+  | 'user_departments'
+
+// ---------------------------------------------------------------------------
+// Dependency graph
+// ---------------------------------------------------------------------------
+//
+// Single source of truth: "when table X changes, bust these query key prefixes."
+// React Query prefix-matches arrays, so ['assets'] invalidates every
+// ['assets', orgId, role, ...filters] variant without knowing the full key.
+//
+// orgId-scoped entries (e.g. ['dashboardStats', orgId]) target only the current
+// org's cache, which matters in multi-tab sessions after an org switch.
+
+type Keys = (orgId: string) => ReadonlyArray<readonly unknown[]>
+
+const TABLE_DEPS: Record<AppTable, Keys> = {
+  // Asset mutations — bust list, single, and dashboard
+  assets: (orgId) => [['assets'], ['asset'], ['dashboardStats', orgId]],
+
+  // Assignment changes affect checked-out state and assigneeSummary on asset rows
+  asset_assignments: (orgId) => [['assets'], ['asset'], ['dashboardStats', orgId]],
+
+  // Reference-data tables: a rename or delete leaves stale denormalized names
+  // in every cached asset row that joined that entity.
+  // FIX: locations and vendors were previously missing ['assets'] invalidation.
+  categories: (orgId) => [['categories', orgId], ['assets'], ['asset'], ['dashboardStats', orgId]],
+  departments: (orgId) => [
+    ['departments', orgId],
+    ['assets'],
+    ['asset'],
+    ['dashboardStats', orgId],
+  ],
+  locations: (orgId) => [['locations', orgId], ['assets'], ['asset'], ['dashboardStats', orgId]],
+  vendors: (orgId) => [['vendors', orgId], ['assets'], ['asset'], ['dashboardStats', orgId]],
+
+  // Audit log writes: feed, per-asset history, and 7-day activity count on dashboard.
+  // FIX: was previously ['recentActivity'] (bare prefix) — now scoped to orgId.
+  // ['assetHistory'] stays as a bare prefix: realtime events don't carry assetId,
+  // so we can't narrow to a specific history query.
+  audit_logs: (orgId) => [['recentActivity', orgId], ['assetHistory'], ['dashboardStats', orgId]],
+
+  // User / invite tables — only affect the org users list
+  profiles: (orgId) => [['orgUsers', orgId]],
+  invites: (orgId) => [['orgUsers', orgId]],
+  user_departments: (orgId) => [['orgUsers', orgId]],
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Invalidate every query key that depends on a table change.
+ *
+ * @example
+ *   // In OrgRealtimeSync:
+ *   .on('postgres_changes', filter('locations'), () =>
+ *     invalidateForTable(queryClient, orgId, 'locations')
+ *   )
+ *
+ *   // In makeEntityHooks onDeleteSuccess:
+ *   onDeleteSuccess: (queryClient, orgId) =>
+ *     invalidateForTable(queryClient, orgId, 'categories')
+ */
+export function invalidateForTable(queryClient: QueryClient, orgId: string, table: AppTable): void {
+  for (const queryKey of TABLE_DEPS[table](orgId)) {
+    void queryClient.invalidateQueries({ queryKey })
+  }
+}

--- a/src/lib/hooks/useCategories.ts
+++ b/src/lib/hooks/useCategories.ts
@@ -2,6 +2,7 @@ import { createCategory, deleteCategory, updateCategory } from '@/app/actions/ca
 import type { Category, CategoryFormInput } from '@/lib/types'
 
 import { makeEntityHooks } from './makeEntityHooks'
+import { invalidateForTable } from './queryInvalidation'
 
 const {
   keys: categoryKeys,
@@ -26,10 +27,7 @@ const {
     update: updateCategory,
     delete: deleteCategory,
   },
-  onDeleteSuccess: (queryClient) => {
-    void queryClient.invalidateQueries({ queryKey: ['assets'] })
-    void queryClient.invalidateQueries({ queryKey: ['asset'] })
-  },
+  onDeleteSuccess: (queryClient, orgId) => invalidateForTable(queryClient, orgId, 'categories'),
 })
 
 export { categoryKeys }

--- a/src/lib/hooks/useDepartments.ts
+++ b/src/lib/hooks/useDepartments.ts
@@ -2,6 +2,7 @@ import { createDepartment, deleteDepartment, updateDepartment } from '@/app/acti
 import type { Department, DepartmentFormInput } from '@/lib/types'
 
 import { makeEntityHooks } from './makeEntityHooks'
+import { invalidateForTable } from './queryInvalidation'
 
 const {
   keys: departmentKeys,
@@ -25,10 +26,7 @@ const {
     update: updateDepartment,
     delete: deleteDepartment,
   },
-  onDeleteSuccess: (queryClient) => {
-    void queryClient.invalidateQueries({ queryKey: ['assets'] })
-    void queryClient.invalidateQueries({ queryKey: ['asset'] })
-  },
+  onDeleteSuccess: (queryClient, orgId) => invalidateForTable(queryClient, orgId, 'departments'),
 })
 
 export { departmentKeys }

--- a/src/lib/hooks/useLocations.ts
+++ b/src/lib/hooks/useLocations.ts
@@ -2,6 +2,7 @@ import { createLocation, deleteLocation, updateLocation } from '@/app/actions/lo
 import type { Location, LocationFormInput } from '@/lib/types'
 
 import { makeEntityHooks } from './makeEntityHooks'
+import { invalidateForTable } from './queryInvalidation'
 
 const {
   keys: locationKeys,
@@ -24,6 +25,7 @@ const {
     update: updateLocation,
     delete: deleteLocation,
   },
+  onDeleteSuccess: (queryClient, orgId) => invalidateForTable(queryClient, orgId, 'locations'),
 })
 
 export { locationKeys }

--- a/src/lib/hooks/useOrgRealtimeSync.ts
+++ b/src/lib/hooks/useOrgRealtimeSync.ts
@@ -4,11 +4,7 @@ import { useEffect } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { useAuth } from '@/providers/AuthProvider'
 
-import { categoryKeys } from './useCategories'
-import { departmentKeys } from './useDepartments'
-import { locationKeys } from './useLocations'
-import { orgUserKeys } from './useOrgUsers'
-import { vendorKeys } from './useVendors'
+import { invalidateForTable, type AppTable } from './queryInvalidation'
 
 export function OrgRealtimeSync() {
   const { user } = useAuth()
@@ -26,43 +22,23 @@ export function OrgRealtimeSync() {
       filter: `org_id=eq.${orgId}`,
     })
 
-    const invalidateAssets = () => {
-      void queryClient.invalidateQueries({ queryKey: ['assets'] })
-      void queryClient.invalidateQueries({ queryKey: ['asset'] })
-      void queryClient.invalidateQueries({ queryKey: ['dashboardStats'] })
-    }
+    const on = (table: AppTable) => () => invalidateForTable(queryClient, orgId, table)
 
     const channel = supabase
       .channel(`org-realtime-${orgId}`)
-      .on('postgres_changes', filter('departments'), () => {
-        void queryClient.invalidateQueries({ queryKey: departmentKeys.all(orgId) })
-        invalidateAssets()
-      })
-      .on('postgres_changes', filter('categories'), () => {
-        void queryClient.invalidateQueries({ queryKey: categoryKeys.all(orgId) })
-        invalidateAssets()
-      })
-      .on('postgres_changes', filter('locations'), () => {
-        void queryClient.invalidateQueries({ queryKey: locationKeys.all(orgId) })
-      })
-      .on('postgres_changes', filter('vendors'), () => {
-        void queryClient.invalidateQueries({ queryKey: vendorKeys.all(orgId) })
-      })
-      .on('postgres_changes', filter('profiles'), () => {
-        void queryClient.invalidateQueries({ queryKey: orgUserKeys.all(orgId) })
-      })
-      .on('postgres_changes', filter('invites'), () => {
-        void queryClient.invalidateQueries({ queryKey: orgUserKeys.all(orgId) })
-      })
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'user_departments' }, () => {
-        void queryClient.invalidateQueries({ queryKey: orgUserKeys.all(orgId) })
-      })
-      .on('postgres_changes', filter('assets'), invalidateAssets)
-      .on('postgres_changes', filter('audit_logs'), () => {
-        void queryClient.invalidateQueries({ queryKey: ['recentActivity'] })
-        void queryClient.invalidateQueries({ queryKey: ['assetHistory'] })
-        void queryClient.invalidateQueries({ queryKey: ['dashboardStats'] })
-      })
+      .on('postgres_changes', filter('departments'), on('departments'))
+      .on('postgres_changes', filter('categories'), on('categories'))
+      .on('postgres_changes', filter('locations'), on('locations'))
+      .on('postgres_changes', filter('vendors'), on('vendors'))
+      .on('postgres_changes', filter('profiles'), on('profiles'))
+      .on('postgres_changes', filter('invites'), on('invites'))
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'user_departments' },
+        on('user_departments')
+      )
+      .on('postgres_changes', filter('assets'), on('assets'))
+      .on('postgres_changes', filter('audit_logs'), on('audit_logs'))
       .subscribe()
 
     return () => {

--- a/src/lib/hooks/useVendors.ts
+++ b/src/lib/hooks/useVendors.ts
@@ -2,6 +2,7 @@ import { createVendor, deleteVendor, updateVendor } from '@/app/actions/vendors'
 import type { Vendor, VendorFormInput } from '@/lib/types'
 
 import { makeEntityHooks } from './makeEntityHooks'
+import { invalidateForTable } from './queryInvalidation'
 
 const {
   keys: vendorKeys,
@@ -27,6 +28,7 @@ const {
     update: updateVendor,
     delete: deleteVendor,
   },
+  onDeleteSuccess: (queryClient, orgId) => invalidateForTable(queryClient, orgId, 'vendors'),
 })
 
 export { vendorKeys }


### PR DESCRIPTION
## Problem

The dependency graph "DB table changed → bust these query keys" was scattered across three files with no single source of truth:

- **`OrgRealtimeSync`** — a custom `invalidateAssets` helper plus per-table handler bodies with hard-coded key arrays
- **`useCategories` / `useDepartments` onDeleteSuccess** — duplicate invalidations that the realtime sync already covers
- **`useLocations` / `useVendors`** — no `onDeleteSuccess` at all (silent bug)

Adding a new hook required updating 2-3 files. Two bugs existed silently:

1. Deleting a **location or vendor** (realtime or mutation) did not invalidate `['assets']` / `['asset']`, leaving cached asset rows with stale denormalized names
2. `audit_logs` realtime changes invalidated bare `['recentActivity']` (matches all orgs) instead of `['recentActivity', orgId]`

## Solution

**`src/lib/hooks/queryInvalidation.ts`** — one file, one function, one record:

```ts
const TABLE_DEPS: Record<AppTable, Keys> = {
  assets:           (orgId) => [['assets'], ['asset'], ['dashboardStats', orgId]],
  asset_assignments:(orgId) => [['assets'], ['asset'], ['dashboardStats', orgId]],
  categories:       (orgId) => [['categories', orgId], ['assets'], ['asset'], ['dashboardStats', orgId]],
  departments:      (orgId) => [['departments', orgId], ['assets'], ['asset'], ['dashboardStats', orgId]],
  locations:        (orgId) => [['locations', orgId], ['assets'], ['asset'], ['dashboardStats', orgId]], // ← bug fix
  vendors:          (orgId) => [['vendors', orgId], ['assets'], ['asset'], ['dashboardStats', orgId]],   // ← bug fix
  audit_logs:       (orgId) => [['recentActivity', orgId], ['assetHistory'], ['dashboardStats', orgId]], // ← bug fix
  profiles:         (orgId) => [['orgUsers', orgId]],
  invites:          (orgId) => [['orgUsers', orgId]],
  user_departments: (orgId) => [['orgUsers', orgId]],
}

export function invalidateForTable(queryClient, orgId, table): void
```

## Files changed

| File | Change |
|---|---|
| `src/lib/hooks/queryInvalidation.ts` | New — `AppTable` union, `TABLE_DEPS` record, `invalidateForTable` |
| `src/lib/hooks/__tests__/queryInvalidation.test.ts` | New — 24 boundary tests |
| `src/lib/hooks/useOrgRealtimeSync.ts` | Removed 5 `*Keys` imports, replaced all handler bodies with `const on = (table) => () => invalidateForTable(qc, orgId, table)` |
| `src/lib/hooks/makeEntityHooks.ts` | `onDeleteSuccess` now receives `orgId` as second arg |
| `src/lib/hooks/useCategories.ts` | Replaced inline `invalidateQueries` calls with `invalidateForTable` |
| `src/lib/hooks/useDepartments.ts` | Same |
| `src/lib/hooks/useLocations.ts` | Added `onDeleteSuccess` — was missing entirely |
| `src/lib/hooks/useVendors.ts` | Same |

## Adding a new hook going forward

1. Add its query key prefix to the relevant `TABLE_DEPS` entry in `queryInvalidation.ts`
2. Done — both realtime and mutation paths pick it up automatically

## Test plan

- [x] 183 total tests pass (11 files)
- [x] 24 new boundary tests covering every table, both bug fixes, and cross-org isolation
- [x] TypeScript strict clean
- [x] Linter + pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)