### PR TITLE
refactor: replace non-atomic soft-delete cascade with Postgres RPC

### DIFF
--- a/src/app/actions/__tests__/_helpers.ts
+++ b/src/app/actions/__tests__/_helpers.ts
@@ -38,12 +38,18 @@ export function makeChain() {
 
 export function makeClients(
   chain: ReturnType<typeof makeChain>,
-  opts: { userId?: string; email?: string; inviteUserByEmail?: ReturnType<typeof vi.fn> } = {}
+  opts: {
+    userId?: string
+    email?: string
+    inviteUserByEmail?: ReturnType<typeof vi.fn>
+    rpc?: ReturnType<typeof vi.fn>
+  } = {}
 ): ActionClients {
   const {
     userId = 'user-actor-0001',
     email = 'actor@example.com',
     inviteUserByEmail = vi.fn().mockResolvedValue({ error: null }),
+    rpc = vi.fn().mockResolvedValue({ error: null }),
   } = opts
 
   return {
@@ -55,6 +61,7 @@ export function makeClients(
     } as unknown as NonNullable<ActionClients['supabase']>,
     admin: {
       from: vi.fn().mockReturnValue(chain),
+      rpc,
       auth: { admin: { inviteUserByEmail, deleteUser: vi.fn().mockResolvedValue({}) } },
     } as unknown as NonNullable<ActionClients['admin']>,
   }

--- a/src/app/actions/__tests__/categories.test.ts
+++ b/src/app/actions/__tests__/categories.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { deleteCategory } from '../categories'
+
+import { makeChain, makeClients, makeUnauthenticatedClients } from './_helpers'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CATEGORY_ID = 'cat-00001'
+
+let chain: ReturnType<typeof makeChain>
+
+beforeEach(() => {
+  chain = makeChain()
+})
+
+// ---------------------------------------------------------------------------
+// deleteCategory
+// ---------------------------------------------------------------------------
+
+describe('deleteCategory', () => {
+  it('returns error when user is not authenticated', async () => {
+    const clients = makeUnauthenticatedClients(chain)
+    const result = await deleteCategory(CATEGORY_ID, clients)
+    expect(result).toEqual({ error: 'Not authenticated' })
+  })
+
+  it('returns error when viewer tries to delete a category', async () => {
+    const clients = makeClients(chain)
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', full_name: 'Viewer', role: 'viewer' },
+    })
+
+    const result = await deleteCategory(CATEGORY_ID, clients)
+    expect(result).toEqual({ error: 'Not authorised' })
+  })
+
+  it('returns error when the rpc call fails', async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: { message: 'function failed' } })
+    const clients = makeClients(chain, { rpc })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
+      .mockResolvedValueOnce({ data: { name: 'Electronics' } })
+
+    const result = await deleteCategory(CATEGORY_ID, clients)
+    expect(result).toEqual({ error: 'function failed' })
+  })
+
+  it('calls rpc with the correct parameters on success', async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: null })
+    const clients = makeClients(chain, { rpc })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
+      .mockResolvedValueOnce({ data: { name: 'Electronics' } })
+
+    const result = await deleteCategory(CATEGORY_ID, clients)
+
+    expect(result).toBeNull()
+    expect(rpc).toHaveBeenCalledWith('soft_delete_with_cascade', {
+      p_entity_table: 'categories',
+      p_entity_id: CATEGORY_ID,
+      p_org_id: 'org-0001',
+      p_asset_fk_col: 'category_id',
+    })
+  })
+
+  it('still returns null when name fetch finds no row (audit falls back to Unknown)', async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: null })
+    const clients = makeClients(chain, { rpc })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
+      .mockResolvedValueOnce({ data: null }) // name row not found
+
+    const result = await deleteCategory(CATEGORY_ID, clients)
+    expect(result).toBeNull()
+  })
+})

--- a/src/app/actions/__tests__/departments.test.ts
+++ b/src/app/actions/__tests__/departments.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { deleteDepartment } from '../departments'
+
+import { makeChain, makeClients, makeUnauthenticatedClients } from './_helpers'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DEPT_ID = 'dept-00001'
+
+let chain: ReturnType<typeof makeChain>
+
+beforeEach(() => {
+  chain = makeChain()
+})
+
+// ---------------------------------------------------------------------------
+// deleteDepartment
+// ---------------------------------------------------------------------------
+
+describe('deleteDepartment', () => {
+  it('returns error when user is not authenticated', async () => {
+    const clients = makeUnauthenticatedClients(chain)
+    const result = await deleteDepartment(DEPT_ID, clients)
+    expect(result).toEqual({ error: 'Not authenticated' })
+  })
+
+  it('returns error when viewer tries to delete a department', async () => {
+    const clients = makeClients(chain)
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { org_id: 'org-0001', full_name: 'Viewer', role: 'viewer' },
+    })
+
+    const result = await deleteDepartment(DEPT_ID, clients)
+    expect(result).toEqual({ error: 'Not authorised' })
+  })
+
+  it('returns error when the rpc call fails', async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: { message: 'function failed' } })
+    const clients = makeClients(chain, { rpc })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
+      .mockResolvedValueOnce({ data: { name: 'Engineering' } })
+
+    const result = await deleteDepartment(DEPT_ID, clients)
+    expect(result).toEqual({ error: 'function failed' })
+  })
+
+  it('calls rpc with the correct parameters on success', async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: null })
+    const clients = makeClients(chain, { rpc })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
+      .mockResolvedValueOnce({ data: { name: 'Engineering' } })
+
+    const result = await deleteDepartment(DEPT_ID, clients)
+
+    expect(result).toBeNull()
+    expect(rpc).toHaveBeenCalledWith('soft_delete_with_cascade', {
+      p_entity_table: 'departments',
+      p_entity_id: DEPT_ID,
+      p_org_id: 'org-0001',
+      p_asset_fk_col: 'department_id',
+    })
+  })
+
+  it('still returns null when name fetch finds no row (audit falls back to Unknown)', async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: null })
+    const clients = makeClients(chain, { rpc })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
+      .mockResolvedValueOnce({ data: null }) // name row not found
+
+    const result = await deleteDepartment(DEPT_ID, clients)
+    expect(result).toBeNull()
+  })
+})

--- a/src/app/actions/_audit.ts
+++ b/src/app/actions/_audit.ts
@@ -10,7 +10,7 @@ type AuditAction =
   | 'invited'
   | 'role_changed'
 
-type EntityType = 'asset' | 'user' | 'department' | 'category' | 'location' | 'vendor'
+export type EntityType = 'asset' | 'user' | 'department' | 'category' | 'location' | 'vendor'
 
 type AuditEntry = {
   orgId: string

--- a/src/app/actions/categories.ts
+++ b/src/app/actions/categories.ts
@@ -1,8 +1,10 @@
 'use server'
 
+import { softDeleteWithCascade } from '@/lib/soft-delete'
 import { CategoryFormSchema, type CategoryFormInput } from '@/lib/types'
 
 import { logAudit } from './_audit'
+import type { ActionClients } from './_context'
 import { getAdminCtx, getContext } from './_context'
 
 export async function createCategory(
@@ -79,33 +81,19 @@ export async function countAssetsInCategory(id: string): Promise<number> {
   return count ?? 0
 }
 
-export async function deleteCategory(id: string): Promise<{ error: string } | null> {
-  const ctx = await getAdminCtx()
-  if ('error' in ctx) return ctx
+export async function deleteCategory(
+  id: string,
+  clients?: ActionClients
+): Promise<{ error: string } | null> {
+  const ctx = await getContext(clients)
+  if (!ctx) return { error: 'Not authenticated' }
+  const permission = ctx.requireRole('admin')
+  if (permission) return permission
 
-  const { data: cat } = await ctx.admin.from('categories').select('name').eq('id', id).maybeSingle()
-
-  const { error } = await ctx.admin
-    .from('categories')
-    .update({ deleted_at: new Date().toISOString() })
-    .eq('id', id)
-    .eq('org_id', ctx.orgId)
-
-  if (error) return { error: error.message }
-
-  // Null out category_id on assets — mirrors what ON DELETE SET NULL would do for a hard delete
-  await ctx.admin
-    .from('assets')
-    .update({ category_id: null })
-    .eq('org_id', ctx.orgId)
-    .eq('category_id', id)
-
-  await logAudit(ctx, {
+  return softDeleteWithCascade(ctx, {
+    entityTable: 'categories',
     entityType: 'category',
     entityId: id,
-    entityName: (cat?.name as string) ?? 'Unknown',
-    action: 'deleted',
+    assetFkColumn: 'category_id',
   })
-
-  return null
 }

--- a/src/app/actions/departments.ts
+++ b/src/app/actions/departments.ts
@@ -1,8 +1,10 @@
 'use server'
 
+import { softDeleteWithCascade } from '@/lib/soft-delete'
 import { DepartmentFormSchema, type DepartmentFormInput } from '@/lib/types'
 
 import { logAudit } from './_audit'
+import type { ActionClients } from './_context'
 import { getAdminCtx, getContext } from './_context'
 
 export async function createDepartment(
@@ -74,37 +76,19 @@ export async function countAssetsInDepartment(id: string): Promise<number> {
   return count ?? 0
 }
 
-export async function deleteDepartment(id: string): Promise<{ error: string } | null> {
-  const ctx = await getAdminCtx()
-  if ('error' in ctx) return ctx
+export async function deleteDepartment(
+  id: string,
+  clients?: ActionClients
+): Promise<{ error: string } | null> {
+  const ctx = await getContext(clients)
+  if (!ctx) return { error: 'Not authenticated' }
+  const permission = ctx.requireRole('admin')
+  if (permission) return permission
 
-  const { data: dept } = await ctx.admin
-    .from('departments')
-    .select('name')
-    .eq('id', id)
-    .maybeSingle()
-
-  const { error } = await ctx.admin
-    .from('departments')
-    .update({ deleted_at: new Date().toISOString() })
-    .eq('id', id)
-    .eq('org_id', ctx.orgId)
-
-  if (error) return { error: error.message }
-
-  // Null out department_id on assets — mirrors what ON DELETE SET NULL would do for a hard delete
-  await ctx.admin
-    .from('assets')
-    .update({ department_id: null })
-    .eq('org_id', ctx.orgId)
-    .eq('department_id', id)
-
-  await logAudit(ctx, {
+  return softDeleteWithCascade(ctx, {
+    entityTable: 'departments',
     entityType: 'department',
     entityId: id,
-    entityName: (dept?.name as string) ?? 'Unknown',
-    action: 'deleted',
+    assetFkColumn: 'department_id',
   })
-
-  return null
 }

--- a/src/lib/soft-delete.ts
+++ b/src/lib/soft-delete.ts
@@ -1,0 +1,55 @@
+import type { EntityType } from '@/app/actions/_audit'
+import { logAudit } from '@/app/actions/_audit'
+import type { ActionContext } from '@/app/actions/_context'
+
+type SoftDeleteOptions = {
+  /** Supabase table name, e.g. 'categories' */
+  entityTable: string
+  /** Audit log entity type */
+  entityType: EntityType
+  /** Row id to soft-delete */
+  entityId: string
+  /**
+   * FK column on `public.assets` to null out.
+   * Common case: a single string, e.g. 'category_id'.
+   */
+  assetFkColumn: string
+}
+
+/**
+ * Soft-deletes an entity and atomically nulls the FK on all referencing
+ * assets via a single Postgres RPC call. Both UPDATEs run inside the
+ * implicit transaction that wraps every PL/pgSQL function — if either
+ * fails, both are rolled back.
+ *
+ * The audit entry is fire-and-forget after a successful RPC.
+ */
+export async function softDeleteWithCascade(
+  ctx: ActionContext,
+  { entityTable, entityType, entityId, assetFkColumn }: SoftDeleteOptions
+): Promise<{ error: string } | null> {
+  // Fetch display name before deleting so the audit log stays readable
+  const { data: row } = await ctx.admin
+    .from(entityTable)
+    .select('name')
+    .eq('id', entityId)
+    .maybeSingle()
+
+  const { error } = await ctx.admin.rpc('soft_delete_with_cascade', {
+    p_entity_table: entityTable,
+    p_entity_id: entityId,
+    p_org_id: ctx.orgId,
+    p_asset_fk_col: assetFkColumn,
+  })
+
+  if (error) return { error: error.message }
+
+  await logAudit(ctx, {
+    entityType,
+    entityId,
+    entityName: (row?.name as string) ?? 'Unknown',
+    action: 'deleted',
+  })
+
+  return null
+}

--- a/supabase/migrations/008_soft_delete_cascade.sql
+++ b/supabase/migrations/008_soft_delete_cascade.sql
@@ -1,0 +1,58 @@
+-- ============================================================
+-- Atomic soft-delete with FK cascade
+--
+-- Replaces the non-atomic two-step pattern in deleteCategory /
+-- deleteDepartment (soft-delete entity, then null FK on assets)
+-- with a single PL/pgSQL function that executes both UPDATEs
+-- inside the implicit transaction that wraps every function call.
+-- If the assets UPDATE fails the entity UPDATE is rolled back.
+--
+-- p_entity_table : table to soft-delete from (allowlisted)
+-- p_entity_id    : row id
+-- p_org_id       : tenant scope (applied to both UPDATEs)
+-- p_asset_fk_col : column on public.assets to null out (allowlisted)
+-- ============================================================
+
+create or replace function public.soft_delete_with_cascade(
+  p_entity_table  text,
+  p_entity_id     uuid,
+  p_org_id        uuid,
+  p_asset_fk_col  text
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Allowlist validation — dynamic identifiers cannot be parameterised;
+  -- an explicit whitelist prevents SQL injection.
+  if p_entity_table not in ('categories', 'departments', 'locations', 'vendors') then
+    raise exception 'soft_delete_with_cascade: unsupported entity table ''%''', p_entity_table;
+  end if;
+
+  if p_asset_fk_col not in ('category_id', 'department_id', 'location_id', 'vendor_id') then
+    raise exception 'soft_delete_with_cascade: unsupported fk column ''%''', p_asset_fk_col;
+  end if;
+
+  -- 1. Soft-delete the entity row
+  execute format(
+    'update public.%I
+        set deleted_at = now()
+      where id      = $1
+        and org_id  = $2
+        and deleted_at is null',
+    p_entity_table
+  ) using p_entity_id, p_org_id;
+
+  -- 2. Null out the FK on all assets in the same org
+  --    Mirrors what ON DELETE SET NULL would do for a hard delete.
+  execute format(
+    'update public.assets
+        set %I = null
+      where %I    = $1
+        and org_id = $2',
+    p_asset_fk_col,
+    p_asset_fk_col
+  ) using p_entity_id, p_org_id;
+end;
+$$;


### PR DESCRIPTION
## Problem

`deleteCategory` and `deleteDepartment` each issued three separate Supabase calls with no transaction boundary:

1. `UPDATE categories SET deleted_at = now()`
2. `UPDATE assets SET category_id = null`
3. `INSERT INTO audit_logs`

If step 2 failed after step 1 succeeded, the entity was soft-deleted but assets retained a stale FK pointing at a ghost record — a silent data integrity bug with no error returned to the caller. The same pattern was copy-pasted verbatim between both files.

## Solution

**`supabase/migrations/008_soft_delete_cascade.sql`** — a `soft_delete_with_cascade()` PL/pgSQL function that executes both UPDATEs inside the implicit transaction that wraps every Postgres function call. Either both commit or both roll back. An explicit allowlist (`categories`, `departments`, `locations`, `vendors` / `category_id`, `department_id`, `location_id`, `vendor_id`) prevents SQL injection via dynamic identifiers.

**`src/lib/soft-delete.ts`** — `softDeleteWithCascade(ctx, options)` TypeScript wrapper. Fetches the entity name for the audit log, calls `ctx.admin.rpc('soft_delete_with_cascade', ...)`, fires `logAudit` after a successful RPC.

**Action callers** — `deleteCategory` and `deleteDepartment` are now 5-line functions: get context → check auth → delegate to `softDeleteWithCascade`. Adding `deleteLocation` or `deleteVendor` follows the same pattern with no new logic.

## Test plan

- [ ] 10 new boundary tests across `categories.test.ts` and `departments.test.ts`: unauthenticated, viewer blocked, rpc error propagated, correct rpc params on success, missing name row falls back gracefully
- [ ] All 205 tests pass, type-check clean
- [ ] **Deploy note**: `008_soft_delete_cascade.sql` must be applied to the Supabase project before deploying this code. The migration is additive (creates a new function, touches no existing tables or policies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)