### PR TITLE
chore: add daily Supabase backup workflow

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,34 @@
+name: Daily database backup
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # 2am UTC daily
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dump database
+        run: pg_dump "${{ secrets.BACKUP_DATABASE_URL }}" | gzip > backup-$(date +%Y-%m-%d).sql.gz
+
+      - name: Checkout backup repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ secrets.BACKUP_REPO }}
+          token: ${{ secrets.BACKUP_REPO_PAT }}
+          path: backup-repo
+
+      - name: Commit and push backup
+        run: |
+          cp backup-$(date +%Y-%m-%d).sql.gz backup-repo/
+          cd backup-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "backup: $(date +%Y-%m-%d)"
+          # Keep only the last 30 backups
+          ls -t *.sql.gz | tail -n +31 | xargs -r git rm
+          git diff --cached --quiet || git commit -m "chore: prune old backups"
+          git push


### PR DESCRIPTION
Runs pg_dump daily at 2am UTC and commits the gzipped dump to a private backup repo. Keeps the last 30 backups, pruning older ones automatically. Supports manual trigger via workflow_dispatch.

**Secrets to add in GitHub Actions settings:**
- `BACKUP_DATABASE_URL` — Supabase direct connection string (Settings → Database → Connection string → URI, use the direct one not the pooler)
- `BACKUP_REPO` — e.g. `elimanzo/trackly-backups`
- `BACKUP_REPO_PAT` — a GitHub PAT with `repo` scope (Settings → Developer settings → Personal access tokens)

**One-time setup:**
1. Create a private repo named `trackly-backups` on GitHub
2. Generate a PAT with `repo` scope
3. Add the three secrets above to this repo (Settings → Secrets → Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)