### PR TITLE
fix: handle empty backup repo on first run

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -13,12 +13,15 @@ jobs:
       - name: Dump database
         run: pg_dump "${{ secrets.BACKUP_DATABASE_URL }}" | gzip > backup-$(date +%Y-%m-%d).sql.gz
 
-      - name: Checkout backup repo
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ secrets.BACKUP_REPO }}
-          token: ${{ secrets.BACKUP_REPO_PAT }}
-          path: backup-repo
+      - name: Clone or init backup repo
+        run: |
+          git clone https://x-access-token:${{ secrets.BACKUP_REPO_PAT }}@github.com/${{ secrets.BACKUP_REPO }}.git backup-repo || true
+          if [ ! -d backup-repo/.git ]; then
+            mkdir -p backup-repo
+            cd backup-repo
+            git init
+            git remote add origin https://x-access-token:${{ secrets.BACKUP_REPO_PAT }}@github.com/${{ secrets.BACKUP_REPO }}.git
+          fi
 
       - name: Commit and push backup
         run: |
@@ -31,4 +34,4 @@ jobs:
           # Keep only the last 30 backups
           ls -t *.sql.gz | tail -n +31 | xargs -r git rm
           git diff --cached --quiet || git commit -m "chore: prune old backups"
-          git push
+          git push --set-upstream origin main


### PR DESCRIPTION
Replaces `actions/checkout` with a manual clone that falls back to `git init` when the backup repo has no commits yet. Also switches to `git push --set-upstream origin main` so the first push creates the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)