### PR TITLE
fix: install postgresql-client-17 to match Supabase server version

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -10,6 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install pg_dump v17
+        run: |
+          sudo apt-get install -y gnupg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+          echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql-client-17
+
       - name: Dump database
         run: |
           set -o pipefail


### PR DESCRIPTION
Runner ships with pg_dump v16 but Supabase is on Postgres 17, causing a version mismatch abort. Adds a step to install `postgresql-client-17` from the official PGDG apt repo before dumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)