### PR TITLE
fix: use explicit pg_dump v17 binary path

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Dump database
         run: |
           set -o pipefail
-          pg_dump "${{ secrets.BACKUP_DATABASE_URL }}" | gzip > backup-$(date +%Y-%m-%d).sql.gz
+          /usr/lib/postgresql/17/bin/pg_dump "${{ secrets.BACKUP_DATABASE_URL }}" | gzip > backup-$(date +%Y-%m-%d).sql.gz
 
       - name: Clone or init backup repo
         run: |


### PR DESCRIPTION
The v16 binary was still first on PATH after installing v17. Use the full path `/usr/lib/postgresql/17/bin/pg_dump` to guarantee the right version runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)