### PR TITLE
fix: duplicate name prevention, checkout UUID nit, quick-create in checkout modals

### DIFF
--- a/src/app/(app)/categories/page.tsx
+++ b/src/app/(app)/categories/page.tsx
@@ -62,13 +62,14 @@ export default function CategoriesPage() {
     setDeleteTarget({ id, assetCount: count })
   }
 
-  function onSubmit(data: CategoryFormInput) {
+  async function onSubmit(data: CategoryFormInput) {
     if (editing) {
       updateCategory(editing.id, data)
+      setSheetOpen(false)
     } else {
-      createCategory(data)
+      const id = await createCategory(data)
+      if (id) setSheetOpen(false)
     }
-    setSheetOpen(false)
   }
 
   return (

--- a/src/app/(app)/departments/page.tsx
+++ b/src/app/(app)/departments/page.tsx
@@ -65,13 +65,14 @@ export default function DepartmentsPage() {
     setDeleteTarget({ id, assetCount: count })
   }
 
-  function onSubmit(data: DepartmentFormInput) {
+  async function onSubmit(data: DepartmentFormInput) {
     if (editing) {
       updateDepartment(editing.id, data)
+      setSheetOpen(false)
     } else {
-      createDepartment(data)
+      const id = await createDepartment(data)
+      if (id) setSheetOpen(false)
     }
-    setSheetOpen(false)
   }
 
   return (

--- a/src/app/(app)/locations/page.tsx
+++ b/src/app/(app)/locations/page.tsx
@@ -56,13 +56,14 @@ export default function LocationsPage() {
     setSheetOpen(true)
   }
 
-  function onSubmit(data: LocationFormInput) {
+  async function onSubmit(data: LocationFormInput) {
     if (editing) {
       updateLocation(editing.id, data)
+      setSheetOpen(false)
     } else {
-      createLocation(data)
+      const id = await createLocation(data)
+      if (id) setSheetOpen(false)
     }
-    setSheetOpen(false)
   }
 
   return (

--- a/src/app/(app)/vendors/page.tsx
+++ b/src/app/(app)/vendors/page.tsx
@@ -58,13 +58,14 @@ export default function VendorsPage() {
     setSheetOpen(true)
   }
 
-  function onSubmit(data: VendorFormInput) {
+  async function onSubmit(data: VendorFormInput) {
     if (editing) {
       updateVendor(editing.id, data)
+      setSheetOpen(false)
     } else {
-      createVendor(data)
+      const id = await createVendor(data)
+      if (id) setSheetOpen(false)
     }
-    setSheetOpen(false)
   }
 
   return (

--- a/src/app/actions/categories.ts
+++ b/src/app/actions/categories.ts
@@ -16,6 +16,16 @@ export async function createCategory(
   const ctx = await getAdminCtx()
   if ('error' in ctx) return ctx
 
+  const { data: existing } = await ctx.admin
+    .from('categories')
+    .select('id')
+    .eq('org_id', ctx.orgId)
+    .ilike('name', input.name.trim())
+    .is('deleted_at', null)
+    .maybeSingle()
+
+  if (existing) return { error: 'A category with that name already exists.' }
+
   const { data, error } = await ctx.admin
     .from('categories')
     .insert({

--- a/src/app/actions/departments.ts
+++ b/src/app/actions/departments.ts
@@ -16,6 +16,16 @@ export async function createDepartment(
   const ctx = await getAdminCtx()
   if ('error' in ctx) return ctx
 
+  const { data: existing } = await ctx.admin
+    .from('departments')
+    .select('id')
+    .eq('org_id', ctx.orgId)
+    .ilike('name', input.name.trim())
+    .is('deleted_at', null)
+    .maybeSingle()
+
+  if (existing) return { error: 'A department with that name already exists.' }
+
   const { data, error } = await ctx.admin
     .from('departments')
     .insert({ org_id: ctx.orgId, name: input.name, description: input.description ?? null })

--- a/src/app/actions/locations.ts
+++ b/src/app/actions/locations.ts
@@ -14,6 +14,16 @@ export async function createLocation(
   const ctx = await getAdminCtx()
   if ('error' in ctx) return ctx
 
+  const { data: existing } = await ctx.admin
+    .from('locations')
+    .select('id')
+    .eq('org_id', ctx.orgId)
+    .ilike('name', input.name.trim())
+    .is('deleted_at', null)
+    .maybeSingle()
+
+  if (existing) return { error: 'A location with that name already exists.' }
+
   const { data, error } = await ctx.admin
     .from('locations')
     .insert({ org_id: ctx.orgId, name: input.name, description: input.description ?? null })

--- a/src/app/actions/vendors.ts
+++ b/src/app/actions/vendors.ts
@@ -14,6 +14,16 @@ export async function createVendor(
   const ctx = await getAdminCtx()
   if ('error' in ctx) return ctx
 
+  const { data: existing } = await ctx.admin
+    .from('vendors')
+    .select('id')
+    .eq('org_id', ctx.orgId)
+    .ilike('name', input.name.trim())
+    .is('deleted_at', null)
+    .maybeSingle()
+
+  if (existing) return { error: 'A vendor with that name already exists.' }
+
   const { data, error } = await ctx.admin
     .from('vendors')
     .insert({

--- a/src/components/assets/AssetForm.tsx
+++ b/src/components/assets/AssetForm.tsx
@@ -7,14 +7,8 @@ import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 import { createAsset, getNextTagForPrefix, getTagPrefixes, updateAsset } from '@/app/actions/assets'
+import { QuickAddDialog } from '@/components/shared/QuickAddDialog'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import {
   Form,
   FormControl,
@@ -46,59 +40,6 @@ import { useOrg } from '@/providers/OrgProvider'
 // ---------------------------------------------------------------------------
 // QuickAddDialog — generic single-name creation dialog
 // ---------------------------------------------------------------------------
-
-interface QuickAddDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  title: string
-  onAdd: (name: string) => Promise<string | null> // returns new id or null on error
-}
-
-function QuickAddDialog({ open, onOpenChange, title, onAdd }: QuickAddDialogProps) {
-  const [name, setName] = useState('')
-  const [saving, setSaving] = useState(false)
-
-  async function handleSave() {
-    if (!name.trim()) return
-    setSaving(true)
-    const id = await onAdd(name.trim())
-    setSaving(false)
-    if (id) {
-      setName('')
-      onOpenChange(false)
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-        </DialogHeader>
-        <Input
-          autoFocus
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              void handleSave()
-            }
-          }}
-        />
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button disabled={!name.trim() || saving} onClick={() => void handleSave()}>
-            Add
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
 
 // ---------------------------------------------------------------------------
 // AssetForm

--- a/src/components/assets/CheckoutModal.tsx
+++ b/src/components/assets/CheckoutModal.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import { Plus } from 'lucide-react'
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 import { checkoutAsset } from '@/app/actions/assets'
+import { QuickAddDialog } from '@/components/shared/QuickAddDialog'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -30,8 +33,8 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
-import { useDepartments } from '@/lib/hooks/useDepartments'
-import { useLocations } from '@/lib/hooks/useLocations'
+import { useDepartmentMutations, useDepartments } from '@/lib/hooks/useDepartments'
+import { useLocationMutations, useLocations } from '@/lib/hooks/useLocations'
 import { CheckoutFormSchema, type CheckoutFormInput } from '@/lib/types'
 import type { TypedAsset } from '@/lib/types'
 import { useAuth } from '@/providers/AuthProvider'
@@ -49,7 +52,10 @@ export function CheckoutModal({ asset, open, onOpenChange, onSuccess }: Checkout
   const { org } = useOrg()
   const deptLabel = org?.departmentLabel ?? 'Department'
   const { data: departments } = useDepartments()
+  const { create: createDepartment } = useDepartmentMutations()
   const { data: locations } = useLocations()
+  const { create: createLocation } = useLocationMutations()
+  const [quickAdd, setQuickAdd] = useState<'department' | 'location' | null>(null)
 
   const form = useForm<CheckoutFormInput>({
     resolver: zodResolver(CheckoutFormSchema),
@@ -77,161 +83,208 @@ export function CheckoutModal({ asset, open, onOpenChange, onSuccess }: Checkout
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Check out {asset.ui.checkoutLabel}</DialogTitle>
-        </DialogHeader>
-        <p className="text-muted-foreground text-sm">
-          <span className="text-foreground font-medium">{asset.name}</span>
-          <span className="ml-2">{asset.ui.checkoutSubtitle}</span>
-        </p>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            <FormField
-              control={form.control}
-              name="assignedToName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Assign to</FormLabel>
-                  <FormControl>
-                    <Input placeholder="Full name" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {asset.ui.availableQty !== null && (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Check out {asset.ui.checkoutLabel}</DialogTitle>
+          </DialogHeader>
+          <p className="text-muted-foreground text-sm">
+            <span className="text-foreground font-medium">{asset.name}</span>
+            <span className="ml-2">{asset.ui.checkoutSubtitle}</span>
+          </p>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <FormField
                 control={form.control}
-                name="quantity"
+                name="assignedToName"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Quantity</FormLabel>
+                    <FormLabel>Assign to</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Full name" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {asset.ui.availableQty !== null && (
+                <FormField
+                  control={form.control}
+                  name="quantity"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Quantity</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={1}
+                          max={asset.ui.availableQty ?? undefined}
+                          step={1}
+                          value={field.value}
+                          onChange={(e) => field.onChange(Number(e.target.value))}
+                        />
+                      </FormControl>
+                      <FormDescription className="text-xs">
+                        {asset.ui.availableQty} in stock
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+
+              <div className="grid grid-cols-2 gap-3">
+                <FormField
+                  control={form.control}
+                  name="departmentId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{deptLabel} (optional)</FormLabel>
+                      <Select
+                        value={field.value ?? '__none__'}
+                        onValueChange={(v) => {
+                          if (v === '__new__') {
+                            setQuickAdd('department')
+                          } else {
+                            field.onChange(v === '__none__' ? null : v)
+                          }
+                        }}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="None" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="__none__">None</SelectItem>
+                          {departments.map((d) => (
+                            <SelectItem key={d.id} value={d.id}>
+                              {d.name}
+                            </SelectItem>
+                          ))}
+                          <SelectItem value="__new__" className="text-primary font-medium">
+                            <span className="flex items-center gap-1.5">
+                              <Plus className="h-3.5 w-3.5" />
+                              Add {deptLabel.toLowerCase()}
+                            </span>
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="locationId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Location (optional)</FormLabel>
+                      <Select
+                        value={field.value ?? '__none__'}
+                        onValueChange={(v) => {
+                          if (v === '__new__') {
+                            setQuickAdd('location')
+                          } else {
+                            field.onChange(v === '__none__' ? null : v)
+                          }
+                        }}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="None" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="__none__">None</SelectItem>
+                          {locations.map((l) => (
+                            <SelectItem key={l.id} value={l.id}>
+                              {l.name}
+                            </SelectItem>
+                          ))}
+                          <SelectItem value="__new__" className="text-primary font-medium">
+                            <span className="flex items-center gap-1.5">
+                              <Plus className="h-3.5 w-3.5" />
+                              Add location
+                            </span>
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="expectedReturnAt"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Expected return date (optional)</FormLabel>
                     <FormControl>
                       <Input
-                        type="number"
-                        min={1}
-                        max={asset.ui.availableQty ?? undefined}
-                        step={1}
-                        value={field.value}
-                        onChange={(e) => field.onChange(Number(e.target.value))}
+                        type="date"
+                        value={field.value ?? ''}
+                        onChange={(e) => field.onChange(e.target.value || null)}
                       />
                     </FormControl>
-                    <FormDescription className="text-xs">
-                      {asset.ui.availableQty} in stock
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            )}
-
-            <div className="grid grid-cols-2 gap-3">
-              <FormField
-                control={form.control}
-                name="departmentId"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{deptLabel} (optional)</FormLabel>
-                    <Select
-                      value={field.value ?? '__none__'}
-                      onValueChange={(v) => field.onChange(v === '__none__' ? null : v)}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="None" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="__none__">None</SelectItem>
-                        {departments.map((d) => (
-                          <SelectItem key={d.id} value={d.id}>
-                            {d.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}
               />
               <FormField
                 control={form.control}
-                name="locationId"
+                name="notes"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Location (optional)</FormLabel>
-                    <Select
-                      value={field.value ?? '__none__'}
-                      onValueChange={(v) => field.onChange(v === '__none__' ? null : v)}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="None" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="__none__">None</SelectItem>
-                        {locations.map((l) => (
-                          <SelectItem key={l.id} value={l.id}>
-                            {l.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormLabel>Notes (optional)</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Reason, accessories included, etc."
+                        rows={2}
+                        {...field}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-            </div>
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={!asset.isAvailable}>
+                  Check out
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
 
-            <FormField
-              control={form.control}
-              name="expectedReturnAt"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Expected return date (optional)</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="date"
-                      value={field.value ?? ''}
-                      onChange={(e) => field.onChange(e.target.value || null)}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="notes"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Notes (optional)</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      placeholder="Reason, accessories included, etc."
-                      rows={2}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={!asset.isAvailable}>
-                Check out
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
-    </Dialog>
+      <QuickAddDialog
+        open={quickAdd === 'department'}
+        onOpenChange={(open) => !open && setQuickAdd(null)}
+        title={`Add ${deptLabel}`}
+        onAdd={async (name) => {
+          const id = await createDepartment({ name })
+          if (id) form.setValue('departmentId', id)
+          return id
+        }}
+      />
+      <QuickAddDialog
+        open={quickAdd === 'location'}
+        onOpenChange={(open) => !open && setQuickAdd(null)}
+        title="Add location"
+        onAdd={async (name) => {
+          const id = await createLocation({ name })
+          if (id) form.setValue('locationId', id)
+          return id
+        }}
+      />
+    </>
   )
 }

--- a/src/components/assets/EditAssignmentModal.tsx
+++ b/src/components/assets/EditAssignmentModal.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useEffect } from 'react'
+import { Plus } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 import { updateAssignment } from '@/app/actions/assets'
+import { QuickAddDialog } from '@/components/shared/QuickAddDialog'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -31,8 +33,8 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
-import { useDepartments } from '@/lib/hooks/useDepartments'
-import { useLocations } from '@/lib/hooks/useLocations'
+import { useDepartmentMutations, useDepartments } from '@/lib/hooks/useDepartments'
+import { useLocationMutations, useLocations } from '@/lib/hooks/useLocations'
 import { CheckoutFormSchema, type AssetAssignment, type CheckoutFormInput } from '@/lib/types'
 import { useOrg } from '@/providers/OrgProvider'
 
@@ -58,7 +60,10 @@ export function EditAssignmentModal({
   const { org } = useOrg()
   const deptLabel = org?.departmentLabel ?? 'Department'
   const { data: departments } = useDepartments()
+  const { create: createDepartment } = useDepartmentMutations()
   const { data: locations } = useLocations()
+  const { create: createLocation } = useLocationMutations()
+  const [quickAdd, setQuickAdd] = useState<'department' | 'location' | null>(null)
 
   const form = useForm<CheckoutFormInput>({
     resolver: zodResolver(CheckoutFormSchema),
@@ -101,157 +106,204 @@ export function EditAssignmentModal({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Edit checkout</DialogTitle>
-        </DialogHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            <FormField
-              control={form.control}
-              name="assignedToName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Assigned to</FormLabel>
-                  <FormControl>
-                    <Input placeholder="Full name" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {isBulk && (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit checkout</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <FormField
                 control={form.control}
-                name="quantity"
+                name="assignedToName"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Quantity</FormLabel>
+                    <FormLabel>Assigned to</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Full name" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {isBulk && (
+                <FormField
+                  control={form.control}
+                  name="quantity"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Quantity</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={1}
+                          max={maxQuantity}
+                          step={1}
+                          value={field.value}
+                          onChange={(e) => field.onChange(Number(e.target.value))}
+                        />
+                      </FormControl>
+                      {maxQuantity !== undefined && (
+                        <FormDescription className="text-xs">
+                          Max {maxQuantity} (available + currently on this assignment)
+                        </FormDescription>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+
+              <div className="grid grid-cols-2 gap-3">
+                <FormField
+                  control={form.control}
+                  name="departmentId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{deptLabel} (optional)</FormLabel>
+                      <Select
+                        value={field.value ?? '__none__'}
+                        onValueChange={(v) => {
+                          if (v === '__new__') {
+                            setQuickAdd('department')
+                          } else {
+                            field.onChange(v === '__none__' ? null : v)
+                          }
+                        }}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="None" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="__none__">None</SelectItem>
+                          {departments.map((d) => (
+                            <SelectItem key={d.id} value={d.id}>
+                              {d.name}
+                            </SelectItem>
+                          ))}
+                          <SelectItem value="__new__" className="text-primary font-medium">
+                            <span className="flex items-center gap-1.5">
+                              <Plus className="h-3.5 w-3.5" />
+                              Add {deptLabel.toLowerCase()}
+                            </span>
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="locationId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Location (optional)</FormLabel>
+                      <Select
+                        value={field.value ?? '__none__'}
+                        onValueChange={(v) => {
+                          if (v === '__new__') {
+                            setQuickAdd('location')
+                          } else {
+                            field.onChange(v === '__none__' ? null : v)
+                          }
+                        }}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="None" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="__none__">None</SelectItem>
+                          {locations.map((l) => (
+                            <SelectItem key={l.id} value={l.id}>
+                              {l.name}
+                            </SelectItem>
+                          ))}
+                          <SelectItem value="__new__" className="text-primary font-medium">
+                            <span className="flex items-center gap-1.5">
+                              <Plus className="h-3.5 w-3.5" />
+                              Add location
+                            </span>
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="expectedReturnAt"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Expected return date (optional)</FormLabel>
                     <FormControl>
                       <Input
-                        type="number"
-                        min={1}
-                        max={maxQuantity}
-                        step={1}
-                        value={field.value}
-                        onChange={(e) => field.onChange(Number(e.target.value))}
+                        type="date"
+                        value={field.value ?? ''}
+                        onChange={(e) => field.onChange(e.target.value || null)}
                       />
                     </FormControl>
-                    {maxQuantity !== undefined && (
-                      <FormDescription className="text-xs">
-                        Max {maxQuantity} (available + currently on this assignment)
-                      </FormDescription>
-                    )}
                     <FormMessage />
                   </FormItem>
                 )}
               />
-            )}
 
-            <div className="grid grid-cols-2 gap-3">
               <FormField
                 control={form.control}
-                name="departmentId"
+                name="notes"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{deptLabel} (optional)</FormLabel>
-                    <Select
-                      value={field.value ?? '__none__'}
-                      onValueChange={(v) => field.onChange(v === '__none__' ? null : v)}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="None" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="__none__">None</SelectItem>
-                        {departments.map((d) => (
-                          <SelectItem key={d.id} value={d.id}>
-                            {d.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormLabel>Notes (optional)</FormLabel>
+                    <FormControl>
+                      <Textarea rows={2} {...field} />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-              <FormField
-                control={form.control}
-                name="locationId"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Location (optional)</FormLabel>
-                    <Select
-                      value={field.value ?? '__none__'}
-                      onValueChange={(v) => field.onChange(v === '__none__' ? null : v)}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="None" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="__none__">None</SelectItem>
-                        {locations.map((l) => (
-                          <SelectItem key={l.id} value={l.id}>
-                            {l.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
 
-            <FormField
-              control={form.control}
-              name="expectedReturnAt"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Expected return date (optional)</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="date"
-                      value={field.value ?? ''}
-                      onChange={(e) => field.onChange(e.target.value || null)}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={form.formState.isSubmitting}>
+                  Save changes
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
 
-            <FormField
-              control={form.control}
-              name="notes"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Notes (optional)</FormLabel>
-                  <FormControl>
-                    <Textarea rows={2} {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={form.formState.isSubmitting}>
-                Save changes
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
-    </Dialog>
+      <QuickAddDialog
+        open={quickAdd === 'department'}
+        onOpenChange={(open) => !open && setQuickAdd(null)}
+        title={`Add ${deptLabel}`}
+        onAdd={async (name) => {
+          const id = await createDepartment({ name })
+          if (id) form.setValue('departmentId', id)
+          return id
+        }}
+      />
+      <QuickAddDialog
+        open={quickAdd === 'location'}
+        onOpenChange={(open) => !open && setQuickAdd(null)}
+        title="Add location"
+        onAdd={async (name) => {
+          const id = await createLocation({ name })
+          if (id) form.setValue('locationId', id)
+          return id
+        }}
+      />
+    </>
   )
 }

--- a/src/components/shared/QuickAddDialog.tsx
+++ b/src/components/shared/QuickAddDialog.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+
+interface QuickAddDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  onAdd: (name: string) => Promise<string | null>
+}
+
+export function QuickAddDialog({ open, onOpenChange, title, onAdd }: QuickAddDialogProps) {
+  const [name, setName] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    if (!name.trim()) return
+    setSaving(true)
+    const id = await onAdd(name.trim())
+    setSaving(false)
+    if (id) {
+      setName('')
+      onOpenChange(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <Input
+          autoFocus
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              void handleSave()
+            }
+          }}
+        />
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={!name.trim() || saving} onClick={() => void handleSave()}>
+            Add
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/lib/checkout/domain.ts
+++ b/src/lib/checkout/domain.ts
@@ -32,7 +32,7 @@ export async function checkoutAsset(
   // both pass the pre-check above before either inserts
   const assignment = await ports.repo.insertAssignment({
     assetId,
-    assignedToUserId: input.assignedToUserId,
+    assignedToUserId: input.assignedToUserId ?? null,
     assignedToName: input.assignedToName,
     assignedById: actorId,
     assignedByName,

--- a/src/lib/types/asset.ts
+++ b/src/lib/types/asset.ts
@@ -170,11 +170,11 @@ export type AssetFormInput = z.infer<typeof AssetFormSchema>
 // ---------------------------------------------------------------------------
 
 export const CheckoutFormSchema = z.object({
-  assignedToUserId: z.string().uuid().nullable(),
+  assignedToUserId: z.string().uuid().nullish(),
   assignedToName: z.string().min(1, 'Assignee name is required').max(200),
   quantity: z.number().int().min(1, 'Quantity must be at least 1'),
-  departmentId: z.string().uuid().nullable(),
-  locationId: z.string().uuid().nullable(),
+  departmentId: z.string().uuid().nullish(),
+  locationId: z.string().uuid().nullish(),
   expectedReturnAt: z.string().nullable(),
   notes: z.string().max(1000).optional(),
 })


### PR DESCRIPTION
## Changes

### Duplicate name prevention
`createDepartment`, `createLocation`, `createCategory`, and `createVendor` now check for a case-insensitive name match before inserting. Returns a friendly error instead of creating a duplicate.

The management pages (departments, locations, categories, vendors) were also closing the sheet immediately without awaiting the create result — so the error toast appeared but the sheet was already gone, making it look like the duplicate went through silently. Fixed by awaiting `create` and only closing the sheet on success.

### Invalid UUID on \"None\" selection in checkout
`CheckoutFormSchema` used `z.string().uuid().nullable()` for optional UUID fields. RHF/Next.js serialization can pass `undefined` for unset fields, which `.nullable()` rejects. Changed to `.nullish()` so both `null` and `undefined` are accepted.

### Quick-create in checkout + edit-assignment modals
Department and location dropdowns in `CheckoutModal` and `EditAssignmentModal` now have the same \"+ Add\" inline option as the asset form. Extracted `QuickAddDialog` from `AssetForm.tsx` into `src/components/shared/QuickAddDialog.tsx`.

## Test plan
- [ ] Create a department with a duplicate name — sheet stays open, error toast appears, no duplicate created
- [ ] Same for locations, categories, vendors
- [ ] Checkout with department = None submits without UUID error
- [ ] \"+ Add department\" / \"+ Add location\" in checkout modal creates and auto-selects
- [ ] Same in edit-assignment modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)