### PR TITLE
feat(multi-org): membership foundation — schema, RLS, types, getContext()

### DIFF
--- a/src/app/actions/__tests__/_context.test.ts
+++ b/src/app/actions/__tests__/_context.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { getContext } from '../_context'
+
+import { makeChain, makeClients, makeUnauthenticatedClients } from './_helpers'
+
+let chain: ReturnType<typeof makeChain>
+
+beforeEach(() => {
+  chain = makeChain()
+})
+
+describe('getContext', () => {
+  it('returns context with correct orgId and role for a user with a membership', async () => {
+    const clients = makeClients(chain, { userId: 'user-001' })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', role: 'admin' } }) // membership
+      .mockResolvedValueOnce({ data: { full_name: 'Alice' } }) // profile name
+
+    const ctx = await getContext(clients)
+
+    expect(ctx).not.toBeNull()
+    expect(ctx?.orgId).toBe('org-0001')
+    expect(ctx?.role).toBe('admin')
+    expect(ctx?.actorName).toBe('Alice')
+    expect(ctx?.userId).toBe('user-001')
+  })
+
+  it('returns null when user has no membership', async () => {
+    const clients = makeClients(chain)
+    chain.maybeSingle.mockResolvedValueOnce({ data: null }) // no membership
+
+    const ctx = await getContext(clients)
+
+    expect(ctx).toBeNull()
+  })
+
+  it('returns null when user is not authenticated', async () => {
+    const clients = makeUnauthenticatedClients(chain)
+
+    const ctx = await getContext(clients)
+
+    expect(ctx).toBeNull()
+  })
+
+  it('includes departmentIds scoped to the active org', async () => {
+    const clients = makeClients(chain, { userId: 'user-001' })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', role: 'editor' } })
+      .mockResolvedValueOnce({ data: { full_name: 'Bob' } })
+    // user_departments returns two rows for org-0001
+    chain.then.mockImplementationOnce((resolve: (v: unknown) => void) =>
+      Promise.resolve({
+        data: [{ department_id: 'dept-001' }, { department_id: 'dept-002' }],
+        error: null,
+      }).then(resolve)
+    )
+
+    const ctx = await getContext(clients)
+
+    expect(ctx?.departmentIds).toEqual(['dept-001', 'dept-002'])
+  })
+})

--- a/src/app/actions/__tests__/_helpers.ts
+++ b/src/app/actions/__tests__/_helpers.ts
@@ -22,8 +22,8 @@ export function makeChain() {
     gt: vi.fn().mockReturnThis(),
     ilike: vi.fn().mockReturnThis(),
     upsert: vi.fn().mockReturnThis(),
-    single: vi.fn(),
-    maybeSingle: vi.fn(),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
     then: vi
       .fn()
       .mockImplementation((resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
@@ -43,6 +43,12 @@ export function makeClients(
     email?: string
     inviteUserByEmail?: ReturnType<typeof vi.fn>
     rpc?: ReturnType<typeof vi.fn>
+    /**
+     * Pre-seed the membership + profile-name maybeSingle calls that getContext()
+     * makes internally. Set to false if the action under test does not call
+     * getContext() (e.g. sendInviteAction, acceptInviteViaGoogleAction).
+     */
+    seedContext?: { orgId?: string; role?: string; actorName?: string } | false
   } = {}
 ): ActionClients {
   const {
@@ -50,7 +56,15 @@ export function makeClients(
     email = 'actor@example.com',
     inviteUserByEmail = vi.fn().mockResolvedValue({ error: null }),
     rpc = vi.fn().mockResolvedValue({ error: null }),
+    seedContext = false,
   } = opts
+
+  if (seedContext !== false) {
+    const { orgId = 'org-0001', role = 'admin', actorName = 'Actor' } = seedContext
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: orgId, role } }) // membership
+      .mockResolvedValueOnce({ data: { full_name: actorName } }) // profile name
+  }
 
   return {
     supabase: {

--- a/src/app/actions/__tests__/assets.test.ts
+++ b/src/app/actions/__tests__/assets.test.ts
@@ -51,20 +51,14 @@ describe('createAsset', () => {
   })
 
   it('returns error when viewer tries to create an asset', async () => {
-    const clients = makeClients(chain)
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', full_name: 'User', role: 'viewer' },
-    })
+    const clients = makeClients(chain, { seedContext: { role: 'viewer' } })
 
     const result = await createAsset(makeInput(), clients)
     expect(result).toEqual({ error: 'Not authorised' })
   })
 
   it('returns friendly error on duplicate asset tag (23505)', async () => {
-    const clients = makeClients(chain)
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', full_name: 'User', role: 'admin' },
-    })
+    const clients = makeClients(chain, { seedContext: { role: 'admin' } })
     chain.single.mockResolvedValueOnce({
       data: null,
       error: { code: '23505', message: 'unique violation' },
@@ -75,10 +69,7 @@ describe('createAsset', () => {
   })
 
   it('returns the new asset id on success', async () => {
-    const clients = makeClients(chain)
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', full_name: 'User', role: 'admin' },
-    })
+    const clients = makeClients(chain, { seedContext: { role: 'admin' } })
     chain.single.mockResolvedValueOnce({ data: { id: 'asset-new-001' }, error: null })
 
     const result = await createAsset(makeInput(), clients)
@@ -98,21 +89,16 @@ describe('deleteAsset', () => {
   })
 
   it('returns error when viewer tries to delete an asset', async () => {
-    const clients = makeClients(chain)
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User', role: 'viewer' } })
-      .mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
+    const clients = makeClients(chain, { seedContext: { role: 'viewer' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
 
     const result = await deleteAsset('asset-0001', clients)
     expect(result).toEqual({ error: 'Not authorised' })
   })
 
   it('returns error when the database update fails', async () => {
-    const clients = makeClients(chain)
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User', role: 'admin' } })
-      .mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
-    // getContext runs Promise.all — first `then` is consumed by user_departments query
+    const clients = makeClients(chain, { seedContext: { role: 'admin' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
     chain.then
       .mockImplementationOnce((resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
         Promise.resolve({ data: [], error: null }).then(resolve, reject)
@@ -126,10 +112,8 @@ describe('deleteAsset', () => {
   })
 
   it('returns null on successful soft-delete', async () => {
-    const clients = makeClients(chain)
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'User', role: 'admin' } })
-      .mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
+    const clients = makeClients(chain, { seedContext: { role: 'admin' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: { name: 'Test Laptop', department_id: null } })
 
     const result = await deleteAsset('asset-0001', clients)
     expect(result).toBeNull()

--- a/src/app/actions/__tests__/auth.test.ts
+++ b/src/app/actions/__tests__/auth.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('googleSignInDestination', () => {
-  it('returns /dashboard when user already has an org', async () => {
+  it('returns /dashboard when user already has a membership', async () => {
     const clients = makeClients(chain)
     chain.maybeSingle.mockResolvedValueOnce({ data: { org_id: 'org-0001' } })
 
@@ -28,9 +28,9 @@ describe('googleSignInDestination', () => {
     expect(result).toEqual({ destination: '/dashboard' })
   })
 
-  it('returns /org/new when user has no org', async () => {
+  it('returns /org/new when user has no membership', async () => {
     const clients = makeClients(chain)
-    chain.maybeSingle.mockResolvedValueOnce({ data: { org_id: null } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: null })
 
     const result = await googleSignInDestination('user-001', clients)
 
@@ -52,15 +52,16 @@ const PENDING_INVITE = {
 }
 
 describe('completeInviteForGoogleUser', () => {
-  it('completes the invite and returns /dashboard when user has no org', async () => {
+  it('creates membership and returns /dashboard when invite is valid', async () => {
     const clients = makeClients(chain)
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: PENDING_INVITE }) // invite lookup
-      .mockResolvedValueOnce({ data: { org_id: null } }) // profile lookup
+    chain.maybeSingle.mockResolvedValueOnce({ data: PENDING_INVITE })
 
     const result = await completeInviteForGoogleUser('user-001', 'invited@example.com', clients)
 
     expect(result).toEqual({ destination: '/dashboard' })
+    expect(chain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'user-001', org_id: 'org-0001', role: 'editor' })
+    )
   })
 
   it('returns null destination when no pending invite exists', async () => {
@@ -72,14 +73,13 @@ describe('completeInviteForGoogleUser', () => {
     expect(result).toEqual({ destination: null })
   })
 
-  it('returns /invite/conflict when user already belongs to an org', async () => {
+  it('always accepts the invite even when user is already in another org', async () => {
     const clients = makeClients(chain)
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: PENDING_INVITE }) // invite lookup
-      .mockResolvedValueOnce({ data: { org_id: 'org-other' } }) // profile lookup
+    chain.maybeSingle.mockResolvedValueOnce({ data: PENDING_INVITE })
 
     const result = await completeInviteForGoogleUser('user-001', 'invited@example.com', clients)
 
-    expect(result).toEqual({ destination: '/invite/conflict' })
+    // Multi-org: no conflict redirect — invite is accepted
+    expect(result).toEqual({ destination: '/dashboard' })
   })
 })

--- a/src/app/actions/__tests__/categories.test.ts
+++ b/src/app/actions/__tests__/categories.test.ts
@@ -28,10 +28,7 @@ describe('deleteCategory', () => {
   })
 
   it('returns error when viewer tries to delete a category', async () => {
-    const clients = makeClients(chain)
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', full_name: 'Viewer', role: 'viewer' },
-    })
+    const clients = makeClients(chain, { seedContext: { role: 'viewer' } })
 
     const result = await deleteCategory(CATEGORY_ID, clients)
     expect(result).toEqual({ error: 'Not authorised' })
@@ -39,10 +36,8 @@ describe('deleteCategory', () => {
 
   it('returns error when the rpc call fails', async () => {
     const rpc = vi.fn().mockResolvedValue({ error: { message: 'function failed' } })
-    const clients = makeClients(chain, { rpc })
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
-      .mockResolvedValueOnce({ data: { name: 'Electronics' } })
+    const clients = makeClients(chain, { rpc, seedContext: { role: 'admin' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: { name: 'Electronics' } })
 
     const result = await deleteCategory(CATEGORY_ID, clients)
     expect(result).toEqual({ error: 'function failed' })
@@ -50,10 +45,8 @@ describe('deleteCategory', () => {
 
   it('calls rpc with the correct parameters on success', async () => {
     const rpc = vi.fn().mockResolvedValue({ error: null })
-    const clients = makeClients(chain, { rpc })
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
-      .mockResolvedValueOnce({ data: { name: 'Electronics' } })
+    const clients = makeClients(chain, { rpc, seedContext: { orgId: 'org-0001', role: 'admin' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: { name: 'Electronics' } })
 
     const result = await deleteCategory(CATEGORY_ID, clients)
 
@@ -68,10 +61,8 @@ describe('deleteCategory', () => {
 
   it('still returns null when name fetch finds no row (audit falls back to Unknown)', async () => {
     const rpc = vi.fn().mockResolvedValue({ error: null })
-    const clients = makeClients(chain, { rpc })
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
-      .mockResolvedValueOnce({ data: null }) // name row not found
+    const clients = makeClients(chain, { rpc, seedContext: { role: 'admin' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: null }) // name row not found
 
     const result = await deleteCategory(CATEGORY_ID, clients)
     expect(result).toBeNull()

--- a/src/app/actions/__tests__/departments.test.ts
+++ b/src/app/actions/__tests__/departments.test.ts
@@ -28,10 +28,7 @@ describe('deleteDepartment', () => {
   })
 
   it('returns error when viewer tries to delete a department', async () => {
-    const clients = makeClients(chain)
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', full_name: 'Viewer', role: 'viewer' },
-    })
+    const clients = makeClients(chain, { seedContext: { role: 'viewer' } })
 
     const result = await deleteDepartment(DEPT_ID, clients)
     expect(result).toEqual({ error: 'Not authorised' })
@@ -39,10 +36,8 @@ describe('deleteDepartment', () => {
 
   it('returns error when the rpc call fails', async () => {
     const rpc = vi.fn().mockResolvedValue({ error: { message: 'function failed' } })
-    const clients = makeClients(chain, { rpc })
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
-      .mockResolvedValueOnce({ data: { name: 'Engineering' } })
+    const clients = makeClients(chain, { rpc, seedContext: { role: 'admin' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: { name: 'Engineering' } })
 
     const result = await deleteDepartment(DEPT_ID, clients)
     expect(result).toEqual({ error: 'function failed' })
@@ -50,10 +45,8 @@ describe('deleteDepartment', () => {
 
   it('calls rpc with the correct parameters on success', async () => {
     const rpc = vi.fn().mockResolvedValue({ error: null })
-    const clients = makeClients(chain, { rpc })
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
-      .mockResolvedValueOnce({ data: { name: 'Engineering' } })
+    const clients = makeClients(chain, { rpc, seedContext: { orgId: 'org-0001', role: 'admin' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: { name: 'Engineering' } })
 
     const result = await deleteDepartment(DEPT_ID, clients)
 
@@ -68,10 +61,8 @@ describe('deleteDepartment', () => {
 
   it('still returns null when name fetch finds no row (audit falls back to Unknown)', async () => {
     const rpc = vi.fn().mockResolvedValue({ error: null })
-    const clients = makeClients(chain, { rpc })
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: { org_id: 'org-0001', full_name: 'Admin', role: 'admin' } })
-      .mockResolvedValueOnce({ data: null }) // name row not found
+    const clients = makeClients(chain, { rpc, seedContext: { role: 'admin' } })
+    chain.maybeSingle.mockResolvedValueOnce({ data: null }) // name row not found
 
     const result = await deleteDepartment(DEPT_ID, clients)
     expect(result).toBeNull()

--- a/src/app/actions/__tests__/invites.test.ts
+++ b/src/app/actions/__tests__/invites.test.ts
@@ -24,12 +24,15 @@ beforeEach(() => {
 
 // ---------------------------------------------------------------------------
 // sendInviteAction
+// sendInviteAction fetches actor context itself (does not call getContext),
+// so there is no context pre-seeding needed.
 // ---------------------------------------------------------------------------
 
 describe('sendInviteAction', () => {
   it('returns error when actor has no organisation', async () => {
     const clients = makeClients(chain, { inviteUserByEmail: mockInviteUserByEmail })
-    chain.single.mockResolvedValueOnce({ data: null })
+    // membership lookup returns null
+    chain.maybeSingle.mockResolvedValueOnce({ data: null })
 
     const result = await sendInviteAction('new@example.com', 'editor', [], clients)
 
@@ -38,10 +41,10 @@ describe('sendInviteAction', () => {
 
   it('returns error when a pending invite already exists for that email', async () => {
     const clients = makeClients(chain, { inviteUserByEmail: mockInviteUserByEmail })
-    chain.single.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
-    })
-    chain.maybeSingle.mockResolvedValueOnce({ data: { id: 'invite-existing-001' } })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', organizations: { name: 'Acme' } } }) // actor membership
+      .mockResolvedValueOnce({ data: { full_name: 'Actor' } }) // actor profile name
+      .mockResolvedValueOnce({ data: { id: 'invite-existing-001' } }) // duplicate invite exists
 
     const result = await sendInviteAction('already@example.com', 'editor', [], clients)
 
@@ -51,15 +54,14 @@ describe('sendInviteAction', () => {
   it('rolls back the invite row by ID and returns error when auth invite fails', async () => {
     mockInviteUserByEmail.mockResolvedValueOnce({ error: { message: 'SMTP unavailable' } })
     const clients = makeClients(chain, { inviteUserByEmail: mockInviteUserByEmail })
+    chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', organizations: { name: 'Acme' } } }) // actor membership
+      .mockResolvedValueOnce({ data: { full_name: 'Actor' } }) // actor profile name
+      .mockResolvedValueOnce({ data: null }) // no duplicate invite
+      .mockResolvedValueOnce({ data: null }) // no existing profile
     chain.single
-      .mockResolvedValueOnce({
-        data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
-      })
       // insert.select.single — returns the new invite's ID
       .mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
-    chain.maybeSingle
-      .mockResolvedValueOnce({ data: null }) // no duplicate invite
-      .mockResolvedValueOnce({ data: null }) // no existing auth user
 
     const result = await sendInviteAction('new@example.com', 'editor', [], clients)
 
@@ -68,37 +70,30 @@ describe('sendInviteAction', () => {
     expect(chain.eq).toHaveBeenCalledWith('id', 'new-invite-001')
   })
 
-  it('keeps invite row and returns success when invitee already has an account', async () => {
+  it('uses OTP and keeps invite row when invitee already has an account', async () => {
     const clients = makeClients(chain, { inviteUserByEmail: mockInviteUserByEmail })
-    chain.single
-      .mockResolvedValueOnce({
-        data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
-      })
-      .mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
     chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', organizations: { name: 'Acme' } } }) // actor membership
+      .mockResolvedValueOnce({ data: { full_name: 'Actor' } }) // actor profile name
       .mockResolvedValueOnce({ data: null }) // no duplicate invite
-      .mockResolvedValueOnce({ data: { id: 'existing-user' } }) // profile exists → use OTP
+      .mockResolvedValueOnce({ data: { id: 'existing-user' } }) // profile exists → OTP
+    chain.single.mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
 
     const result = await sendInviteAction('existing@example.com', 'editor', [], clients)
 
     expect(result).toEqual({ error: null })
-    // inviteUserByEmail must not be called — we used OTP instead
     expect(mockInviteUserByEmail).not.toHaveBeenCalled()
-    // Must NOT have rolled back the invite row
     expect(chain.delete).not.toHaveBeenCalled()
   })
 
   it('returns null error on success', async () => {
     const clients = makeClients(chain, { inviteUserByEmail: mockInviteUserByEmail })
-    chain.single
-      .mockResolvedValueOnce({
-        data: { org_id: 'org-0001', full_name: 'Actor', organizations: { name: 'Acme' } },
-      })
-      // insert.select.single
-      .mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
     chain.maybeSingle
+      .mockResolvedValueOnce({ data: { org_id: 'org-0001', organizations: { name: 'Acme' } } }) // actor membership
+      .mockResolvedValueOnce({ data: { full_name: 'Actor' } }) // actor profile name
       .mockResolvedValueOnce({ data: null }) // no duplicate invite
-      .mockResolvedValueOnce({ data: null }) // no existing auth user
+      .mockResolvedValueOnce({ data: null }) // no existing profile
+    chain.single.mockResolvedValueOnce({ data: { id: 'new-invite-001' }, error: null })
 
     const result = await sendInviteAction('new@example.com', 'viewer', [], clients)
 
@@ -120,13 +115,17 @@ const PENDING_INVITE = {
 }
 
 describe('acceptInviteViaGoogleAction', () => {
-  it('applies org/role/departments and returns null error on success', async () => {
+  it('creates membership row and returns null error on success', async () => {
     const clients = makeClients(chain, { email: 'invited@example.com' })
     chain.maybeSingle.mockResolvedValueOnce({ data: PENDING_INVITE })
 
     const result = await acceptInviteViaGoogleAction('Alex Rivera', clients)
 
     expect(result).toEqual({ error: null })
+    // membership upsert must have been called
+    expect(chain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'user-actor-0001', org_id: 'org-0001', role: 'editor' })
+    )
   })
 
   it('returns error when no pending invite exists', async () => {

--- a/src/app/actions/__tests__/users.test.ts
+++ b/src/app/actions/__tests__/users.test.ts
@@ -19,11 +19,14 @@ beforeEach(() => {
 
 // ---------------------------------------------------------------------------
 // updateUserRoleAction
+// Calls getContext() internally, so each test pre-seeds 2 maybeSingle calls
+// (membership + profile name) via seedContext before setting up test-specific mocks.
 // ---------------------------------------------------------------------------
 
 describe('updateUserRoleAction', () => {
-  it('returns error when actor profile has no organisation', async () => {
+  it('returns error when actor has no organisation', async () => {
     const clients = makeClients(chain, { userId: ACTOR_ID })
+    // membership lookup returns null → no org
     chain.maybeSingle.mockResolvedValueOnce({ data: null })
 
     const result = await updateUserRoleAction(TARGET_ID, 'editor', clients)
@@ -32,9 +35,9 @@ describe('updateUserRoleAction', () => {
   })
 
   it('returns error when actor role is not owner or admin', async () => {
-    const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', role: 'editor', full_name: 'Actor' },
+    const clients = makeClients(chain, {
+      userId: ACTOR_ID,
+      seedContext: { orgId: 'org-0001', role: 'editor', actorName: 'Actor' },
     })
 
     const result = await updateUserRoleAction(TARGET_ID, 'viewer', clients)
@@ -43,9 +46,9 @@ describe('updateUserRoleAction', () => {
   })
 
   it('returns error when actor tries to change their own role', async () => {
-    const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' },
+    const clients = makeClients(chain, {
+      userId: ACTOR_ID,
+      seedContext: { orgId: 'org-0001', role: 'admin', actorName: 'Actor' },
     })
 
     const result = await updateUserRoleAction(ACTOR_ID, 'editor', clients)
@@ -54,11 +57,11 @@ describe('updateUserRoleAction', () => {
   })
 
   it('returns error when target user is not found in the org', async () => {
-    const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' },
+    const clients = makeClients(chain, {
+      userId: ACTOR_ID,
+      seedContext: { orgId: 'org-0001', role: 'admin', actorName: 'Actor' },
     })
-    chain.single.mockResolvedValueOnce({ data: null })
+    chain.maybeSingle.mockResolvedValueOnce({ data: null }) // target membership not found
 
     const result = await updateUserRoleAction(TARGET_ID, 'editor', clients)
 
@@ -66,11 +69,13 @@ describe('updateUserRoleAction', () => {
   })
 
   it('returns error when target user is the org owner', async () => {
-    const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' },
+    const clients = makeClients(chain, {
+      userId: ACTOR_ID,
+      seedContext: { orgId: 'org-0001', role: 'admin', actorName: 'Actor' },
     })
-    chain.single.mockResolvedValueOnce({ data: { role: 'owner', full_name: 'Owner' } })
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { role: 'owner', profiles: { full_name: 'Owner' } },
+    })
 
     const result = await updateUserRoleAction(TARGET_ID, 'editor', clients)
 
@@ -78,11 +83,13 @@ describe('updateUserRoleAction', () => {
   })
 
   it('returns null error on successful role change', async () => {
-    const clients = makeClients(chain, { userId: ACTOR_ID })
-    chain.maybeSingle.mockResolvedValueOnce({
-      data: { org_id: 'org-0001', role: 'admin', full_name: 'Actor' },
+    const clients = makeClients(chain, {
+      userId: ACTOR_ID,
+      seedContext: { orgId: 'org-0001', role: 'admin', actorName: 'Actor' },
     })
-    chain.single.mockResolvedValueOnce({ data: { role: 'editor', full_name: 'Target User' } })
+    chain.maybeSingle.mockResolvedValueOnce({
+      data: { role: 'editor', profiles: { full_name: 'Target User' } },
+    })
 
     const result = await updateUserRoleAction(TARGET_ID, 'viewer', clients)
 

--- a/src/app/actions/_context.ts
+++ b/src/app/actions/_context.ts
@@ -26,19 +26,34 @@ export async function getContext(clients?: ActionClients): Promise<ActionContext
   if (!user) return null
 
   const admin = clients?.admin ?? createAdminClient()
+
+  // Step 1: resolve the user's active membership (first one in Phase 1;
+  // Phase 2 will select by org slug from the URL)
+  const { data: membership } = await admin
+    .from('user_org_memberships')
+    .select('org_id, role')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (!membership?.org_id) return null
+
+  // Step 2: fetch display name + scoped departments in parallel
   const [{ data: profile }, { data: deptRows }] = await Promise.all([
-    admin.from('profiles').select('org_id, full_name, role').eq('id', user.id).maybeSingle(),
-    admin.from('user_departments').select('department_id').eq('user_id', user.id),
+    admin.from('profiles').select('full_name').eq('id', user.id).maybeSingle(),
+    admin
+      .from('user_departments')
+      .select('department_id')
+      .eq('user_id', user.id)
+      .eq('org_id', membership.org_id),
   ])
 
-  if (!profile?.org_id) return null
-  const role = profile.role as UserRole
+  const role = membership.role as UserRole
   const departmentIds = (deptRows ?? []).map((r: { department_id: string }) => r.department_id)
 
   return {
     userId: user.id,
-    orgId: profile.org_id as string,
-    actorName: (profile.full_name as string) ?? 'Unknown',
+    orgId: membership.org_id as string,
+    actorName: (profile?.full_name as string) ?? 'Unknown',
     role,
     departmentIds,
     admin,

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -11,7 +11,6 @@ export async function completeInviteForGoogleUser(
 ): Promise<{ destination: string | null } | { error: string }> {
   const admin = clients?.admin ?? createAdminClient()
 
-  // Look up a pending, non-expired invite for this email
   const { data: invite } = await admin
     .from('invites')
     .select('*')
@@ -22,30 +21,30 @@ export async function completeInviteForGoogleUser(
 
   if (!invite) return { destination: null }
 
-  // Check if the user already belongs to an org
-  const { data: profile } = await admin
-    .from('profiles')
-    .select('org_id')
-    .eq('id', userId)
-    .maybeSingle()
-
-  if (profile?.org_id) return { destination: '/invite/conflict' }
-
-  // Apply invite: upsert profile, assign departments, mark accepted
+  // Multi-org: always accept the invite — users can belong to multiple orgs
   const { error: profileError } = await admin.from('profiles').upsert({
     id: userId,
-    org_id: invite.org_id,
-    role: invite.role as string,
-    invite_status: 'active',
     updated_at: new Date().toISOString(),
   })
   if (profileError) return { error: profileError.message }
 
+  const { error: membershipError } = await admin.from('user_org_memberships').upsert({
+    user_id: userId,
+    org_id: invite.org_id,
+    role: invite.role as string,
+    invite_status: 'active',
+  })
+  if (membershipError) return { error: membershipError.message }
+
   const deptIds = (invite.department_ids as string[] | null) ?? []
   if (deptIds.length > 0) {
-    const { error: deptError } = await admin
-      .from('user_departments')
-      .insert(deptIds.map((department_id: string) => ({ user_id: userId, department_id })))
+    const { error: deptError } = await admin.from('user_departments').insert(
+      deptIds.map((department_id: string) => ({
+        user_id: userId,
+        department_id,
+        org_id: invite.org_id,
+      }))
+    )
     if (deptError) return { error: deptError.message }
   }
 
@@ -65,11 +64,11 @@ export async function googleSignInDestination(
   clients?: ActionClients
 ): Promise<{ destination: string }> {
   const admin = clients?.admin ?? createAdminClient()
-  const { data: profile } = await admin
-    .from('profiles')
+  const { data: membership } = await admin
+    .from('user_org_memberships')
     .select('org_id')
-    .eq('id', userId)
+    .eq('user_id', userId)
     .maybeSingle()
 
-  return { destination: profile?.org_id ? '/dashboard' : '/org/new' }
+  return { destination: membership?.org_id ? '/dashboard' : '/org/new' }
 }

--- a/src/app/actions/invites.ts
+++ b/src/app/actions/invites.ts
@@ -28,21 +28,29 @@ export async function sendInviteAction(
 
   const admin = clients?.admin ?? createAdminClient()
 
-  // Fetch inviter profile + org name
-  const { data: profile } = await admin
-    .from('profiles')
-    .select('org_id, full_name, organizations(name)')
-    .eq('id', user.id)
-    .single()
+  // Fetch actor's active membership and display name in parallel
+  const [{ data: actorMembership }, { data: actorProfile }] = await Promise.all([
+    admin
+      .from('user_org_memberships')
+      .select('org_id, organizations(name)')
+      .eq('user_id', user.id)
+      .maybeSingle(),
+    admin.from('profiles').select('full_name').eq('id', user.id).maybeSingle(),
+  ])
 
-  if (!profile?.org_id) return { error: 'No organisation found' }
+  if (!actorMembership?.org_id) return { error: 'No organisation found' }
+
+  const orgId = actorMembership.org_id as string
+  const orgs = actorMembership.organizations as { name: string }[] | { name: string } | null
+  const orgName = (Array.isArray(orgs) ? orgs[0]?.name : orgs?.name) ?? ''
+  const actorName = (actorProfile?.full_name as string) ?? 'Your team'
 
   // Prevent duplicate pending invites
   const { data: existing } = await admin
     .from('invites')
     .select('id')
     .eq('email', email)
-    .eq('org_id', profile.org_id)
+    .eq('org_id', orgId)
     .is('accepted_at', null)
     .maybeSingle()
 
@@ -50,16 +58,15 @@ export async function sendInviteAction(
 
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
 
-  // Capture the inserted row's ID so the rollback delete is precise
   const { data: newInvite, error: insertError } = await admin
     .from('invites')
     .insert({
-      org_id: profile.org_id,
+      org_id: orgId,
       email,
       role,
       token: crypto.randomUUID(),
       invited_by: user.id,
-      invited_by_name: profile.full_name,
+      invited_by_name: actorName,
       expires_at: expiresAt,
       department_ids: departmentIds,
     })
@@ -68,35 +75,19 @@ export async function sendInviteAction(
 
   if (insertError) return { error: insertError.message }
 
-  // Send invite email via Supabase (routes through configured SMTP)
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
-  const orgs = profile.organizations as unknown as { name: string }[] | { name: string } | null
-  const orgName = (Array.isArray(orgs) ? orgs[0]?.name : orgs?.name) ?? ''
   const next = `/invite/accept?org=${encodeURIComponent(orgName)}`
   const redirectTo = `${appUrl}/auth/callback?next=${encodeURIComponent(next)}`
 
-  // Check if an auth user already exists for this email (e.g. they previously had an org
-  // and deleted it, or left). inviteUserByEmail fails for existing users, so send a magic
-  // link instead — they'll sign in and land on the invite accept page.
+  // Check whether an auth user already exists for this email. If so, send a
+  // magic link instead of inviteUserByEmail (which fails for existing users).
   const { data: existingProfile } = await admin
     .from('profiles')
-    .select('id, org_id')
+    .select('id')
     .eq('email', email)
     .maybeSingle()
 
-  if (existingProfile?.org_id) {
-    await admin
-      .from('invites')
-      .delete()
-      .eq('id', (newInvite as { id: string }).id)
-    return { error: 'This person is already a member of another organization.' }
-  }
-
   if (existingProfile) {
-    // Use a raw client with implicit flow so the magic link uses hash tokens
-    // (#access_token=…) instead of a PKCE code. signInWithOtp called server-side
-    // would store the PKCE verifier in the admin's browser — useless when a
-    // different person (the invitee) clicks the link in their own browser.
     const implicitClient = createRawClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -118,23 +109,16 @@ export async function sendInviteAction(
 
   const { error: authError } = await admin.auth.admin.inviteUserByEmail(email, {
     redirectTo,
-    data: {
-      org_name: orgName,
-      invited_by_name: (profile.full_name as string) ?? 'Your team',
-    },
+    data: { org_name: orgName, invited_by_name: actorName },
   })
 
   if (authError) {
-    // If the email belongs to an existing auth user (e.g. signed up via Google),
-    // inviteUserByEmail fails but the invite row is valid — the pending invite
-    // will be auto-completed when they next sign in via Google.
     const alreadyExists =
       authError.message.toLowerCase().includes('already been registered') ||
       authError.message.toLowerCase().includes('already registered') ||
       authError.message.toLowerCase().includes('user already exists')
 
     if (!alreadyExists) {
-      // Only roll back for unexpected errors (e.g. SMTP failure)
       await admin
         .from('invites')
         .delete()
@@ -174,21 +158,29 @@ export async function acceptInviteViaGoogleAction(
 
   const { error: profileError } = await admin.from('profiles').upsert({
     id: user.id,
-    org_id: invite.org_id,
     full_name: fullName,
     email: user.email,
-    role: invite.role as string,
-    invite_status: 'active',
     updated_at: new Date().toISOString(),
   })
-
   if (profileError) return { error: profileError.message }
+
+  const { error: membershipError } = await admin.from('user_org_memberships').upsert({
+    user_id: user.id,
+    org_id: invite.org_id,
+    role: invite.role as string,
+    invite_status: 'active',
+  })
+  if (membershipError) return { error: membershipError.message }
 
   const deptIds = (invite.department_ids as string[] | null) ?? []
   if (deptIds.length > 0) {
-    const { error: deptError } = await admin
-      .from('user_departments')
-      .insert(deptIds.map((department_id: string) => ({ user_id: user.id, department_id })))
+    const { error: deptError } = await admin.from('user_departments').insert(
+      deptIds.map((department_id: string) => ({
+        user_id: user.id,
+        department_id,
+        org_id: invite.org_id,
+      }))
+    )
     if (deptError) return { error: deptError.message }
   }
 
@@ -216,8 +208,6 @@ export async function acceptInviteAction(
 
   const admin = createAdminClient()
 
-  // Find the pending invite for this email (normalize to lowercase — Supabase
-  // lowercases emails on auth user creation so mixed-case invites must match)
   const { data: invite } = await admin
     .from('invites')
     .select('*')
@@ -228,33 +218,37 @@ export async function acceptInviteAction(
 
   if (!invite) return { error: 'Invite not found or has expired. Ask your admin to resend it.' }
 
-  // Upsert the profile (trigger may have created a bare row already)
   const { error: profileError } = await admin.from('profiles').upsert({
     id: user.id,
-    org_id: invite.org_id,
     full_name: fullName,
     email: user.email,
-    role: invite.role as string,
-    invite_status: 'active',
     updated_at: new Date().toISOString(),
   })
-
   if (profileError) return { error: profileError.message }
 
-  // Set the user's password so they can log in with email + password going forward
+  const { error: membershipError } = await admin.from('user_org_memberships').upsert({
+    user_id: user.id,
+    org_id: invite.org_id,
+    role: invite.role as string,
+    invite_status: 'active',
+  })
+  if (membershipError) return { error: membershipError.message }
+
   const { error: pwError } = await admin.auth.admin.updateUserById(user.id, { password })
   if (pwError) return { error: pwError.message }
 
-  // Apply pre-assigned departments from the invite
   const deptIds = (invite.department_ids as string[] | null) ?? []
   if (deptIds.length > 0) {
-    const { error: deptError } = await admin
-      .from('user_departments')
-      .insert(deptIds.map((department_id: string) => ({ user_id: user.id, department_id })))
+    const { error: deptError } = await admin.from('user_departments').insert(
+      deptIds.map((department_id: string) => ({
+        user_id: user.id,
+        department_id,
+        org_id: invite.org_id,
+      }))
+    )
     if (deptError) return { error: deptError.message }
   }
 
-  // Mark invite accepted
   await admin
     .from('invites')
     .update({ accepted_at: new Date().toISOString() })

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -52,12 +52,13 @@ export async function completeOnboardingSetup(
     return { error: orgError.message }
   }
 
-  const { error: profileError } = await admin
-    .from('profiles')
-    .update({ org_id: orgData.id, invite_status: 'active' })
-    .eq('id', user.id)
-
-  if (profileError) return { error: profileError.message }
+  const { error: membershipError } = await admin.from('user_org_memberships').insert({
+    user_id: user.id,
+    org_id: orgData.id,
+    role: 'owner',
+    invite_status: 'active',
+  })
+  if (membershipError) return { error: membershipError.message }
 
   if (departments.length > 0) {
     const { error: deptError } = await admin
@@ -73,22 +74,18 @@ export async function completeOnboardingSetup(
     if (catError) return { error: catError.message }
   }
 
-  // Return success — client will do a full-page navigation to flush stale AuthProvider state
   return { error: null }
 }
 
 export async function createOrganization(
   input: CreateOrganizationInput
 ): Promise<{ error: string } | never> {
-  // Auth check via server client (reads session from cookies)
   const supabase = await createClient()
   const {
     data: { user },
   } = await supabase.auth.getUser()
   if (!user) redirect('/login')
 
-  // Use admin client for DB writes — bypasses RLS, safe because we've
-  // already verified the user identity above via getUser()
   const admin = createAdminClient()
 
   const { data: org, error: orgError } = await admin
@@ -104,7 +101,12 @@ export async function createOrganization(
     return { error: orgError.message }
   }
 
-  await admin.from('profiles').update({ org_id: org.id, invite_status: 'active' }).eq('id', user.id)
+  await admin.from('user_org_memberships').insert({
+    user_id: user.id,
+    org_id: org.id,
+    role: 'owner',
+    invite_status: 'active',
+  })
 
   redirect('/setup/departments')
 }
@@ -120,19 +122,19 @@ export async function updateOrganization(
 
   const admin = createAdminClient()
 
-  const { data: profile } = await admin
-    .from('profiles')
+  const { data: membership } = await admin
+    .from('user_org_memberships')
     .select('org_id, role')
-    .eq('id', user.id)
-    .single()
+    .eq('user_id', user.id)
+    .maybeSingle()
 
-  if (!profile?.org_id) return { error: 'No organisation found' }
-  const denied = createPolicy({ role: profile.role as UserRole, departmentIds: [] }).enforce(
+  if (!membership?.org_id) return { error: 'No organisation found' }
+  const denied = createPolicy({ role: membership.role as UserRole, departmentIds: [] }).enforce(
     'department:manage'
   )
   if (denied) return denied
 
-  const isOwner = profile.role === 'owner'
+  const isOwner = membership.role === 'owner'
 
   const patch: Record<string, unknown> = {}
   if (isOwner && input.name !== undefined) patch.name = input.name
@@ -142,7 +144,7 @@ export async function updateOrganization(
   if (input.assetTableConfig !== undefined) patch.asset_table_config = input.assetTableConfig
   if (input.reportConfig !== undefined) patch.report_config = input.reportConfig
 
-  const { error } = await admin.from('organizations').update(patch).eq('id', profile.org_id)
+  const { error } = await admin.from('organizations').update(patch).eq('id', membership.org_id)
 
   if (error) {
     if (error.code === '23505') return { error: 'That URL slug is already taken.' }
@@ -165,46 +167,19 @@ export async function deleteOrgAction(): Promise<{ error: string } | { error: nu
 
   const admin = createAdminClient()
 
-  const { data: profile } = await admin
-    .from('profiles')
+  const { data: membership } = await admin
+    .from('user_org_memberships')
     .select('org_id, role')
-    .eq('id', user.id)
-    .single()
+    .eq('user_id', user.id)
+    .maybeSingle()
 
-  if (!profile?.org_id) return { error: 'No organisation found' }
-  if (profile.role !== 'owner') return { error: 'Only the organisation owner can delete it' }
+  if (!membership?.org_id) return { error: 'No organisation found' }
+  if (membership.role !== 'owner') return { error: 'Only the organisation owner can delete it' }
 
-  const orgId = profile.org_id as string
-
-  // Detach all members first so their accounts survive the org deletion
-  const { error: detachMembersError } = await admin
-    .from('profiles')
-    .update({
-      org_id: null,
-      role: 'viewer',
-      invite_status: 'pending',
-      updated_at: new Date().toISOString(),
-    })
-    .eq('org_id', orgId)
-    .neq('id', user.id)
-
-  if (detachMembersError) return { error: detachMembersError.message }
-
-  // Clear owner's own profile
-  const { error: detachOwnerError } = await admin
-    .from('profiles')
-    .update({
-      org_id: null,
-      role: 'viewer',
-      invite_status: 'pending',
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', user.id)
-
-  if (detachOwnerError) return { error: detachOwnerError.message }
+  const orgId = membership.org_id as string
 
   // Delete the org — cascades departments, categories, locations, vendors,
-  // assets, invites, audit_logs, user_departments
+  // assets, invites, audit_logs, user_departments, user_org_memberships
   const { error } = await admin.from('organizations').delete().eq('id', orgId)
 
   return { error: error?.message ?? null }

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -24,26 +24,31 @@ export async function updateUserRoleAction(
   if (userId === ctx.userId) return { error: 'You cannot change your own role' }
 
   const { data: target } = await ctx.admin
-    .from('profiles')
-    .select('role, full_name')
-    .eq('id', userId)
+    .from('user_org_memberships')
+    .select('role, profiles(full_name)')
+    .eq('user_id', userId)
     .eq('org_id', ctx.orgId)
-    .single()
+    .maybeSingle()
 
   if (!target) return { error: 'User not found' }
   if (target.role === 'owner') return { error: "Cannot change the owner's role" }
 
   const { error } = await ctx.admin
-    .from('profiles')
+    .from('user_org_memberships')
     .update({ role })
-    .eq('id', userId)
+    .eq('user_id', userId)
     .eq('org_id', ctx.orgId)
+
+  const profileData = target.profiles as { full_name: string } | { full_name: string }[] | null
+  const targetName =
+    (Array.isArray(profileData) ? profileData[0]?.full_name : profileData?.full_name) ??
+    'Unknown user'
 
   if (!error) {
     await logAudit(ctx, {
       entityType: 'user',
       entityId: userId,
-      entityName: (target.full_name as string) ?? 'Unknown user',
+      entityName: targetName,
       action: 'role_changed',
       changes: { role: { old: target.role, new: role } },
     })
@@ -63,18 +68,23 @@ export async function updateUserDepartmentsAction(
   const denied = ctx.requireRole('admin')
   if (denied) return denied
 
-  // Replace all department memberships in a transaction-like manner
+  // Replace all department memberships for this user within the active org
   const { error: deleteError } = await ctx.admin
     .from('user_departments')
     .delete()
     .eq('user_id', userId)
+    .eq('org_id', ctx.orgId)
 
   if (deleteError) return { error: deleteError.message }
 
   if (departmentIds.length > 0) {
-    const { error: insertError } = await ctx.admin
-      .from('user_departments')
-      .insert(departmentIds.map((department_id) => ({ user_id: userId, department_id })))
+    const { error: insertError } = await ctx.admin.from('user_departments').insert(
+      departmentIds.map((department_id) => ({
+        user_id: userId,
+        department_id,
+        org_id: ctx.orgId,
+      }))
+    )
     if (insertError) return { error: insertError.message }
   }
 
@@ -91,7 +101,6 @@ export async function revokeInviteAction(
   const denied = ctx.requireRole('admin')
   if (denied) return denied
 
-  // Grab the email before deleting so we can clean up the auth user
   const { data: invite } = await ctx.admin
     .from('invites')
     .select('email')
@@ -108,21 +117,24 @@ export async function revokeInviteAction(
   if (error) return { error: error.message }
 
   // Remove the pending auth user so the same email can be re-invited.
-  // inviteUserByEmail creates an auth user immediately; without deleting it
-  // a subsequent invite to the same address would fail with "already registered".
-  // The on_auth_user_created trigger creates a profile with org_id = null for
-  // pending users, so we can look up the user ID that way.
+  // A pending user has a profile row but no membership row yet.
   if (invite?.email) {
     const { data: pendingProfile } = await ctx.admin
       .from('profiles')
       .select('id')
       .eq('email', invite.email)
-      .is('org_id', null)
       .maybeSingle()
 
     if (pendingProfile) {
-      await ctx.admin.auth.admin.deleteUser(pendingProfile.id as string)
-      // profile row is removed automatically via ON DELETE CASCADE on auth.users
+      const { data: membership } = await ctx.admin
+        .from('user_org_memberships')
+        .select('user_id')
+        .eq('user_id', pendingProfile.id as string)
+        .maybeSingle()
+
+      if (!membership) {
+        await ctx.admin.auth.admin.deleteUser(pendingProfile.id as string)
+      }
     }
   }
 
@@ -142,24 +154,23 @@ export async function removeUserAction(
   if (userId === ctx.userId) return { error: 'You cannot remove yourself' }
 
   const { data: target } = await ctx.admin
-    .from('profiles')
+    .from('user_org_memberships')
     .select('role')
-    .eq('id', userId)
+    .eq('user_id', userId)
     .eq('org_id', ctx.orgId)
-    .single()
+    .maybeSingle()
 
   if (!target) return { error: 'User not found' }
   if (target.role === 'owner') return { error: 'Cannot remove the org owner' }
 
   const { error } = await ctx.admin
-    .from('profiles')
+    .from('user_org_memberships')
     .update({ invite_status: 'deactivated' })
-    .eq('id', userId)
+    .eq('user_id', userId)
     .eq('org_id', ctx.orgId)
 
   if (error) return { error: error.message }
 
-  // Delete the auth user so they can be re-invited cleanly later
   await ctx.admin.auth.admin.deleteUser(userId)
 
   return { error: null }
@@ -178,27 +189,27 @@ export async function leaveOrgAction(): Promise<{ error: string } | { error: nul
 
   const admin = createAdminClient()
 
-  const { data: profile } = await admin
-    .from('profiles')
+  const { data: membership } = await admin
+    .from('user_org_memberships')
     .select('org_id, role')
-    .eq('id', user.id)
+    .eq('user_id', user.id)
     .maybeSingle()
 
-  if (!profile?.org_id) return { error: 'You are not in an organisation' }
-  if (profile.role === 'owner')
-    return { error: 'Owners cannot leave — delete the organisation instead' }
+  if (!membership?.org_id) return { error: 'You are not in an organisation' }
+  if (membership.role === 'owner')
+    return { error: 'Owners cannot leave — transfer ownership or delete the organisation first' }
 
-  await admin.from('user_departments').delete().eq('user_id', user.id)
+  await admin
+    .from('user_departments')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('org_id', membership.org_id)
 
   const { error } = await admin
-    .from('profiles')
-    .update({
-      org_id: null,
-      role: 'viewer',
-      invite_status: 'pending',
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', user.id)
+    .from('user_org_memberships')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('org_id', membership.org_id)
 
   return { error: error?.message ?? null }
 }
@@ -216,16 +227,15 @@ export async function deleteAccountAction(): Promise<{ error: string } | { error
 
   const admin = createAdminClient()
 
-  const { data: profile } = await admin
-    .from('profiles')
+  const { data: membership } = await admin
+    .from('user_org_memberships')
     .select('org_id')
-    .eq('id', user.id)
+    .eq('user_id', user.id)
     .maybeSingle()
 
-  if (profile?.org_id)
+  if (membership?.org_id)
     return { error: 'Leave or delete your organisation before deleting your account' }
 
-  // Deleting the auth user cascades to the profile row
   const { error } = await admin.auth.admin.deleteUser(user.id)
 
   return { error: error?.message ?? null }
@@ -242,17 +252,22 @@ export async function requestPasswordResetAction(
   const normalised = email.toLowerCase().trim()
   const admin = clients?.admin ?? createAdminClient()
 
-  // Only send resets to known, active members — prevents strangers from
-  // spamming reset emails to emails they don't own.
+  // Only send resets to known users who have at least one active membership
   const { data: profile } = await admin
     .from('profiles')
     .select('id')
     .eq('email', normalised)
-    .not('org_id', 'is', null)
     .maybeSingle()
 
-  // Always return success — don't reveal whether the email is registered.
   if (!profile) return { error: null }
+
+  const { data: membership } = await admin
+    .from('user_org_memberships')
+    .select('user_id')
+    .eq('user_id', profile.id as string)
+    .maybeSingle()
+
+  if (!membership) return { error: null }
 
   const headersList = await headers()
   const origin =
@@ -260,8 +275,6 @@ export async function requestPasswordResetAction(
 
   const redirectTo = `${origin}/auth/callback?next=${encodeURIComponent('/reset-password?recovery=1')}`
 
-  // Use the regular server client — resetPasswordForEmail actually sends the
-  // email. admin.generateLink only returns the URL without sending.
   const supabase = clients?.supabase ?? (await createClient())
   await supabase.auth.resetPasswordForEmail(normalised, { redirectTo })
 

--- a/src/components/assets/AssetForm.tsx
+++ b/src/components/assets/AssetForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useQueryClient } from '@tanstack/react-query'
 import { Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
@@ -52,6 +53,7 @@ interface AssetFormProps {
 
 export function AssetForm({ asset, defaultAssetTag }: AssetFormProps) {
   const router = useRouter()
+  const queryClient = useQueryClient()
   const { data: departments } = useDepartments()
   const { org } = useOrg()
   const { create: createDepartment } = useDepartmentMutations()
@@ -166,6 +168,7 @@ export function AssetForm({ asset, defaultAssetTag }: AssetFormProps) {
         form.setError('assetTag', { message: result.error })
         return
       }
+      void queryClient.invalidateQueries({ queryKey: ['assets'] })
       router.push(`/assets/${result.id}`)
     }
   }

--- a/src/lib/hooks/useOrgUsers.ts
+++ b/src/lib/hooks/useOrgUsers.ts
@@ -16,20 +16,45 @@ export const orgUserKeys = {
   all: (orgId: string) => ['orgUsers', orgId] as const,
 }
 
-type Row = Record<string, unknown>
-type UDRow = { department_id: string; departments: { id: string; name: string } | null }
+type MembershipRow = {
+  user_id: string
+  org_id: string
+  role: string
+  invite_status: string
+  profiles: {
+    full_name: string
+    email: string
+    avatar_url: string | null
+    created_at: string
+    updated_at: string
+  } | null
+}
+
+type UDRow = {
+  user_id: string
+  department_id: string
+  departments: { id: string; name: string } | null
+}
+
+type InvRow = Record<string, unknown>
 
 async function fetchOrgUsers(
   orgId: string
 ): Promise<{ users: ProfileWithDepartments[]; pendingInvites: Invite[] }> {
   const supabase = createClient()
-  const [profsResult, invsResult] = await Promise.all([
+  const [membershipsResult, deptsResult, invsResult] = await Promise.all([
     supabase
-      .from('profiles')
-      .select('*, user_departments(department_id, departments(id, name))')
+      .from('user_org_memberships')
+      .select(
+        'user_id, org_id, role, invite_status, profiles(full_name, email, avatar_url, created_at, updated_at)'
+      )
       .eq('org_id', orgId)
       .neq('invite_status', 'deactivated')
-      .order('full_name'),
+      .order('user_id'),
+    supabase
+      .from('user_departments')
+      .select('user_id, department_id, departments(id, name)')
+      .eq('org_id', orgId),
     supabase
       .from('invites')
       .select('*')
@@ -37,26 +62,36 @@ async function fetchOrgUsers(
       .is('accepted_at', null)
       .gt('expires_at', new Date().toISOString()),
   ])
-  if (profsResult.error) throw new Error(profsResult.error.message)
+  if (membershipsResult.error) throw new Error(membershipsResult.error.message)
+  if (deptsResult.error) throw new Error(deptsResult.error.message)
   if (invsResult.error) throw new Error(invsResult.error.message)
 
-  const users = ((profsResult.data ?? []) as Row[]).map((r) => ({
-    id: r.id as string,
-    orgId: (r.org_id as string | null) ?? null,
-    fullName: r.full_name as string,
-    email: r.email as string,
-    avatarUrl: (r.avatar_url as string | null) ?? null,
-    role: r.role as ProfileWithDepartments['role'],
-    inviteStatus: r.invite_status as ProfileWithDepartments['inviteStatus'],
-    createdAt: r.created_at as string,
-    updatedAt: r.updated_at as string,
-    departmentIds: ((r.user_departments as UDRow[]) ?? []).map((ud) => ud.department_id),
-    departmentNames: ((r.user_departments as UDRow[]) ?? []).map(
-      (ud) => ud.departments?.name ?? ''
-    ),
-  }))
+  const deptsByUser = new Map<string, UDRow[]>()
+  for (const ud of (deptsResult.data ?? []) as unknown as UDRow[]) {
+    const arr = deptsByUser.get(ud.user_id) ?? []
+    arr.push(ud)
+    deptsByUser.set(ud.user_id, arr)
+  }
 
-  const pendingInvites = ((invsResult.data ?? []) as Row[]).map((r) => ({
+  const users = ((membershipsResult.data ?? []) as unknown as MembershipRow[]).map((m) => {
+    const p = m.profiles
+    const depts = deptsByUser.get(m.user_id) ?? []
+    return {
+      id: m.user_id,
+      orgId: m.org_id,
+      fullName: p?.full_name ?? '',
+      email: p?.email ?? '',
+      avatarUrl: p?.avatar_url ?? null,
+      role: m.role as ProfileWithDepartments['role'],
+      inviteStatus: m.invite_status as ProfileWithDepartments['inviteStatus'],
+      createdAt: p?.created_at ?? '',
+      updatedAt: p?.updated_at ?? '',
+      departmentIds: depts.map((ud) => ud.department_id),
+      departmentNames: depts.map((ud) => ud.departments?.name ?? ''),
+    }
+  })
+
+  const pendingInvites = ((invsResult.data ?? []) as InvRow[]).map((r) => ({
     id: r.id as string,
     orgId: r.org_id as string,
     email: r.email as string,

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -13,17 +13,28 @@ export const InviteStatusSchema = z.enum(['active', 'pending', 'deactivated'])
 export type InviteStatus = z.infer<typeof InviteStatusSchema>
 
 // ---------------------------------------------------------------------------
-// Profile
+// Org membership (one row per user per org — carries role and invite status)
+// ---------------------------------------------------------------------------
+
+export const OrgMembershipSchema = z.object({
+  userId: z.string().uuid(),
+  orgId: z.string().uuid(),
+  role: UserRoleSchema,
+  inviteStatus: InviteStatusSchema,
+  createdAt: z.string().datetime(),
+})
+
+export type OrgMembership = z.infer<typeof OrgMembershipSchema>
+
+// ---------------------------------------------------------------------------
+// Profile (identity only — role/org live on OrgMembership)
 // ---------------------------------------------------------------------------
 
 export const ProfileSchema = z.object({
   id: z.string().uuid(),
-  orgId: z.string().uuid().nullable(),
   fullName: z.string().min(1).max(100),
   email: z.string().email(),
   avatarUrl: z.string().url().nullable(),
-  role: UserRoleSchema,
-  inviteStatus: InviteStatusSchema,
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 })
@@ -36,6 +47,7 @@ export type Profile = z.infer<typeof ProfileSchema>
 
 export const UserDepartmentSchema = z.object({
   userId: z.string().uuid(),
+  orgId: z.string().uuid(),
   departmentId: z.string().uuid(),
   createdAt: z.string().datetime(),
 })
@@ -84,7 +96,13 @@ export type UpdateProfileInput = z.infer<typeof UpdateProfileSchema>
 // Profile with department list (for display in tables)
 // ---------------------------------------------------------------------------
 
+// ProfileWithDepartments is the shape returned by AuthProvider to the UI.
+// In Phase 1 it carries the first (active) membership's org/role/inviteStatus
+// for backward compatibility. Phase 2 will replace orgId with memberships[].
 export type ProfileWithDepartments = Profile & {
+  orgId: string | null
+  role: UserRole
+  inviteStatus: InviteStatus
   departmentIds: string[]
   departmentNames: string[]
 }

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -22,26 +22,48 @@ async function fetchProfile(userId: string): Promise<ProfileWithDepartments | nu
   const supabase = createClient()
   const { data, error } = await supabase
     .from('profiles')
-    .select(`*, user_departments ( department_id, departments ( id, name ) )`)
+    .select(
+      `
+      *,
+      user_org_memberships ( org_id, role, invite_status ),
+      user_departments ( department_id, org_id, departments ( id, name ) )
+    `
+    )
     .eq('id', userId)
     .maybeSingle()
 
   if (error || !data) return null
 
-  type UDRow = { department_id: string; departments: { id: string; name: string } | null }
+  type MembershipRow = { org_id: string; role: string; invite_status: string }
+  type UDRow = {
+    department_id: string
+    org_id: string
+    departments: { id: string; name: string } | null
+  }
+
+  // Phase 1: use the first membership as the active org context.
+  // Phase 2 will replace this with URL-based org selection.
+  const memberships = (data.user_org_memberships as MembershipRow[]) ?? []
+  const activeMembership = memberships[0] ?? null
+
+  const allDepts = (data.user_departments as UDRow[]) ?? []
+  const scopedDepts = activeMembership
+    ? allDepts.filter((ud) => ud.org_id === activeMembership.org_id)
+    : []
 
   return {
     id: data.id as string,
-    orgId: data.org_id as string | null,
+    orgId: activeMembership?.org_id ?? null,
     fullName: data.full_name as string,
     email: data.email as string,
     avatarUrl: (data.avatar_url as string | null) ?? null,
-    role: data.role as ProfileWithDepartments['role'],
-    inviteStatus: data.invite_status as ProfileWithDepartments['inviteStatus'],
+    role: (activeMembership?.role ?? 'viewer') as ProfileWithDepartments['role'],
+    inviteStatus: (activeMembership?.invite_status ??
+      'pending') as ProfileWithDepartments['inviteStatus'],
     createdAt: data.created_at as string,
     updatedAt: data.updated_at as string,
-    departmentIds: (data.user_departments as UDRow[]).map((ud) => ud.department_id),
-    departmentNames: (data.user_departments as UDRow[]).map((ud) => ud.departments?.name ?? ''),
+    departmentIds: scopedDepts.map((ud) => ud.department_id),
+    departmentNames: scopedDepts.map((ud) => ud.departments?.name ?? ''),
   }
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -82,13 +82,13 @@ export async function proxy(request: NextRequest) {
   }
 
   // Authenticated — check org membership via DB (single primary-key lookup)
-  const { data: profile } = await supabase
-    .from('profiles')
+  const { data: membership } = await supabase
+    .from('user_org_memberships')
     .select('org_id')
-    .eq('id', user.id)
+    .eq('user_id', user.id)
     .maybeSingle()
 
-  const hasOrg = !!profile?.org_id
+  const hasOrg = !!membership?.org_id
 
   // Auth callback must always run — it may replace the current session (invite flow)
   // Public routes (forgot/reset password) are always accessible regardless of auth state

--- a/supabase/migrations/009_multi_org_memberships.sql
+++ b/supabase/migrations/009_multi_org_memberships.sql
@@ -1,0 +1,364 @@
+-- ============================================================
+-- Multi-org membership
+-- Replace profiles.org_id / profiles.role / profiles.invite_status
+-- with a user_org_memberships join table so one account can belong
+-- to many organisations with independent roles.
+-- ============================================================
+
+-- ============================================================
+-- 1. Create user_org_memberships join table
+-- ============================================================
+
+create table public.user_org_memberships (
+  user_id       uuid not null references public.profiles (id) on delete cascade,
+  org_id        uuid not null references public.organizations (id) on delete cascade,
+  role          public.user_role not null default 'viewer',
+  invite_status public.invite_status not null default 'pending',
+  created_at    timestamptz not null default now(),
+  primary key (user_id, org_id)
+);
+
+create index on public.user_org_memberships (org_id);
+
+alter table public.user_org_memberships enable row level security;
+
+-- ============================================================
+-- 2. Migrate existing single-org memberships from profiles
+-- ============================================================
+
+insert into public.user_org_memberships (user_id, org_id, role, invite_status, created_at)
+select id, org_id, role, invite_status, created_at
+from public.profiles
+where org_id is not null;
+
+-- ============================================================
+-- 3. Add denormalized org_id to user_departments for RLS efficiency
+-- ============================================================
+
+alter table public.user_departments
+  add column org_id uuid references public.organizations (id) on delete cascade;
+
+update public.user_departments ud
+set org_id = d.org_id
+from public.departments d
+where d.id = ud.department_id;
+
+alter table public.user_departments
+  alter column org_id set not null;
+
+create index on public.user_departments (org_id);
+
+-- ============================================================
+-- 4. Drop RLS policies that reference get_my_org_id() / get_my_role()
+-- ============================================================
+
+drop policy if exists "members can view their org" on public.organizations;
+drop policy if exists "owner or admin can update org" on public.organizations;
+
+drop policy if exists "users can view profiles in their org" on public.profiles;
+drop policy if exists "admin/owner can update profiles in org" on public.profiles;
+
+drop policy if exists "org members can view departments" on public.departments;
+drop policy if exists "admin/owner can manage departments" on public.departments;
+
+drop policy if exists "org members can view user_departments" on public.user_departments;
+drop policy if exists "admin/owner can manage user_departments" on public.user_departments;
+
+drop policy if exists "org members can view categories" on public.categories;
+drop policy if exists "admin/owner can manage categories" on public.categories;
+
+drop policy if exists "org members can view locations" on public.locations;
+drop policy if exists "admin/owner can manage locations" on public.locations;
+
+drop policy if exists "org members can view vendors" on public.vendors;
+drop policy if exists "admin/owner can manage vendors" on public.vendors;
+
+drop policy if exists "org members can view their assets" on public.assets;
+drop policy if exists "editor+ can insert assets" on public.assets;
+drop policy if exists "editor+ can update assets in their scope" on public.assets;
+drop policy if exists "admin/owner can delete assets" on public.assets;
+
+drop policy if exists "org members can view assignments" on public.asset_assignments;
+drop policy if exists "editor+ can manage assignments" on public.asset_assignments;
+
+drop policy if exists "admin/owner can view invites" on public.invites;
+drop policy if exists "admin/owner can create invites" on public.invites;
+drop policy if exists "admin/owner can update invites" on public.invites;
+
+drop policy if exists "org members can view audit logs" on public.audit_logs;
+drop policy if exists "authenticated users can insert audit logs" on public.audit_logs;
+
+-- ============================================================
+-- 5. Drop old single-org helper functions
+-- ============================================================
+
+drop function if exists public.get_my_org_id();
+drop function if exists public.get_my_role();
+
+-- ============================================================
+-- 6. New helper functions
+-- ============================================================
+
+create or replace function public.get_my_org_ids()
+returns uuid[]
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(array_agg(org_id), '{}')
+  from public.user_org_memberships
+  where user_id = (select auth.uid())
+$$;
+
+-- Returns the caller's role within a specific org (null if not a member)
+create or replace function public.get_my_role_in_org(p_org_id uuid)
+returns public.user_role
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select role
+  from public.user_org_memberships
+  where user_id = (select auth.uid()) and org_id = p_org_id
+$$;
+
+-- ============================================================
+-- 7. Recreate RLS policies using the new helpers
+-- ============================================================
+
+-- user_org_memberships ----------------------------------------
+
+create policy "users can view own and org memberships"
+  on public.user_org_memberships for select
+  using (
+    user_id = (select auth.uid())
+    or org_id = any(public.get_my_org_ids())
+  );
+
+create policy "admin/owner can manage memberships"
+  on public.user_org_memberships for all
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+-- organizations -----------------------------------------------
+
+create policy "members can view their orgs"
+  on public.organizations for select
+  using (id = any(public.get_my_org_ids()));
+
+create policy "owner or admin can update org"
+  on public.organizations for update
+  using (
+    id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(id) in ('owner', 'admin')
+  );
+
+-- profiles ----------------------------------------------------
+
+create policy "users can view profiles in their orgs"
+  on public.profiles for select
+  using (
+    id = (select auth.uid())
+    or exists (
+      select 1 from public.user_org_memberships m
+      where m.user_id = profiles.id
+        and m.org_id = any(public.get_my_org_ids())
+    )
+  );
+
+-- departments -------------------------------------------------
+
+create policy "org members can view departments"
+  on public.departments for select
+  using (org_id = any(public.get_my_org_ids()));
+
+create policy "admin/owner can manage departments"
+  on public.departments for all
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+-- user_departments --------------------------------------------
+
+create policy "org members can view user_departments"
+  on public.user_departments for select
+  using (org_id = any(public.get_my_org_ids()));
+
+create policy "admin/owner can manage user_departments"
+  on public.user_departments for all
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+-- categories --------------------------------------------------
+
+create policy "org members can view categories"
+  on public.categories for select
+  using (org_id = any(public.get_my_org_ids()));
+
+create policy "admin/owner can manage categories"
+  on public.categories for all
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+-- locations ---------------------------------------------------
+
+create policy "org members can view locations"
+  on public.locations for select
+  using (org_id = any(public.get_my_org_ids()));
+
+create policy "admin/owner can manage locations"
+  on public.locations for all
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+-- vendors -----------------------------------------------------
+
+create policy "org members can view vendors"
+  on public.vendors for select
+  using (org_id = any(public.get_my_org_ids()));
+
+create policy "admin/owner can manage vendors"
+  on public.vendors for all
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+-- assets ------------------------------------------------------
+
+create policy "org members can view their assets"
+  on public.assets for select
+  using (
+    org_id = any(public.get_my_org_ids())
+    and deleted_at is null
+    and (
+      public.get_my_role_in_org(org_id) in ('owner', 'admin')
+      or public.has_department_access(assets.department_id)
+    )
+  );
+
+create policy "editor+ can insert assets"
+  on public.assets for insert
+  with check (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin', 'editor')
+  );
+
+create policy "editor+ can update assets in their scope"
+  on public.assets for update
+  using (
+    org_id = any(public.get_my_org_ids())
+    and (
+      public.get_my_role_in_org(org_id) in ('owner', 'admin')
+      or (
+        public.get_my_role_in_org(org_id) = 'editor'
+        and public.has_department_access(assets.department_id)
+      )
+    )
+  );
+
+create policy "admin/owner can delete assets"
+  on public.assets for delete
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+-- asset_assignments -------------------------------------------
+
+create policy "org members can view assignments"
+  on public.asset_assignments for select
+  using (
+    exists (
+      select 1 from public.assets a
+      where a.id = asset_assignments.asset_id
+        and a.org_id = any(public.get_my_org_ids())
+    )
+  );
+
+create policy "editor+ can manage assignments"
+  on public.asset_assignments for all
+  using (
+    exists (
+      select 1 from public.assets a
+      where a.id = asset_assignments.asset_id
+        and a.org_id = any(public.get_my_org_ids())
+        and public.get_my_role_in_org(a.org_id) in ('owner', 'admin', 'editor')
+    )
+  );
+
+-- invites -----------------------------------------------------
+
+create policy "admin/owner can view invites"
+  on public.invites for select
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+create policy "admin/owner can create invites"
+  on public.invites for insert
+  with check (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+create policy "admin/owner can update invites"
+  on public.invites for update
+  using (
+    org_id = any(public.get_my_org_ids())
+    and public.get_my_role_in_org(org_id) in ('owner', 'admin')
+  );
+
+-- audit_logs --------------------------------------------------
+
+create policy "org members can view audit logs"
+  on public.audit_logs for select
+  using (org_id = any(public.get_my_org_ids()));
+
+create policy "authenticated users can insert audit logs"
+  on public.audit_logs for insert
+  with check (org_id = any(public.get_my_org_ids()));
+
+-- ============================================================
+-- 8. Drop deprecated columns from profiles
+-- ============================================================
+
+drop index if exists public.profiles_org_id_idx;
+
+alter table public.profiles
+  drop column if exists org_id,
+  drop column if exists role,
+  drop column if exists invite_status;
+
+-- ============================================================
+-- 9. Update handle_new_user — no longer sets role/invite_status
+-- ============================================================
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, full_name, email)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'full_name', split_part(new.email, '@', 1)),
+    new.email
+  );
+  return new;
+end;
+$$;

--- a/supabase/seeds/001_initial_data.sql
+++ b/supabase/seeds/001_initial_data.sql
@@ -65,6 +65,8 @@ begin
   delete from public.invites         where org_id = v_org_id;
   delete from public.user_departments
     where user_id in (u_owner, u_admin, u_editor, u_viewer);
+  delete from public.user_org_memberships
+    where user_id in (u_owner, u_admin, u_editor, u_viewer);
   delete from public.profiles        where id in (u_owner, u_admin, u_editor, u_viewer);
   delete from public.organizations   where id = v_org_id;
   delete from auth.users             where id in (u_owner, u_admin, u_editor, u_viewer);
@@ -101,22 +103,12 @@ begin
   insert into public.organizations (id, name, slug, owner_id)
   values (v_org_id, 'Acme Corp', 'acme-corp', u_owner);
 
-  -- ── PROFILES (update trigger-created rows) ────────────────
-  update public.profiles set
-    org_id = v_org_id, role = 'owner', invite_status = 'active'
-  where id = u_owner;
-
-  update public.profiles set
-    org_id = v_org_id, role = 'admin', invite_status = 'active'
-  where id = u_admin;
-
-  update public.profiles set
-    org_id = v_org_id, role = 'editor', invite_status = 'active'
-  where id = u_editor;
-
-  update public.profiles set
-    org_id = v_org_id, role = 'viewer', invite_status = 'active'
-  where id = u_viewer;
+  -- ── ORG MEMBERSHIPS ───────────────────────────────────────
+  insert into public.user_org_memberships (user_id, org_id, role, invite_status) values
+    (u_owner,  v_org_id, 'owner',  'active'),
+    (u_admin,  v_org_id, 'admin',  'active'),
+    (u_editor, v_org_id, 'editor', 'active'),
+    (u_viewer, v_org_id, 'viewer', 'active');
 
   -- ── DEPARTMENTS ───────────────────────────────────────────
   insert into public.departments (id, org_id, name, description) values
@@ -127,14 +119,14 @@ begin
     (d_mktg,    v_org_id, 'Marketing',       'Brand, campaigns, content, and growth');
 
   -- Editor → IT + Operations
-  insert into public.user_departments (user_id, department_id) values
-    (u_editor, d_it),
-    (u_editor, d_ops);
+  insert into public.user_departments (user_id, department_id, org_id) values
+    (u_editor, d_it,      v_org_id),
+    (u_editor, d_ops,     v_org_id);
 
   -- Viewer → Finance + Human Resources
-  insert into public.user_departments (user_id, department_id) values
-    (u_viewer, d_finance),
-    (u_viewer, d_hr);
+  insert into public.user_departments (user_id, department_id, org_id) values
+    (u_viewer, d_finance, v_org_id),
+    (u_viewer, d_hr,      v_org_id);
 
   -- ── CATEGORIES ────────────────────────────────────────────
   insert into public.categories (id, org_id, name, description) values

--- a/supabase/seeds/002_bulk_items.sql
+++ b/supabase/seeds/002_bulk_items.sql
@@ -54,9 +54,10 @@ begin
     raise exception 'No organization found with seed 001 departments — run seed 001 first.';
   end if;
 
-  select id, full_name into v_user_id, v_user_name
-    from public.profiles
-    where org_id = v_org_id and role = 'owner'
+  select p.id, p.full_name into v_user_id, v_user_name
+    from public.profiles p
+    join public.user_org_memberships m on m.user_id = p.id
+    where m.org_id = v_org_id and m.role = 'owner'
     limit 1;
 
   -- resolve existing departments and locations by name


### PR DESCRIPTION
## Parent PRD

#51

## Parent issue

#52

## What was built

Replaces `profiles.org_id / role / invite_status` with a `user_org_memberships` join table. One account can now belong to multiple organisations with independent roles per org. This is the tracer bullet for the multi-org feature — every layer (migration → RLS → types → server context → tests) is wired through the new model before any routing changes land.

## Changes

**Database (migration 009)**
- New `user_org_memberships (user_id, org_id, role, invite_status)` table with RLS
- `user_departments` gains a denormalized `org_id` column for RLS efficiency
- `get_my_org_ids()` replaces `get_my_org_id()` — returns `uuid[]`
- `get_my_role_in_org(org_id)` replaces `get_my_role()` — scoped per org
- All policies updated to `= ANY(get_my_org_ids())` and `get_my_role_in_org()`
- `profiles.org_id`, `profiles.role`, `profiles.invite_status` dropped
- `handle_new_user` trigger updated (no longer sets role/invite_status)
- Existing single-org memberships migrated to the new table

**Server layer**
- `getContext()` reads membership + role from `user_org_memberships`
- All invite accept flows upsert membership rows
- `completeInviteForGoogleUser` no longer blocks on existing org membership
- `leaveOrgAction` deletes the membership row; blocks on owner
- `deleteAccountAction` checks memberships, not `profiles.org_id`
- `updateUserRoleAction` / `removeUserAction` target `user_org_memberships`
- `updateUserDepartmentsAction` scopes deletes/inserts to `ctx.orgId`
- `createOrg` / `completeOnboardingSetup` insert owner membership row
- `AuthProvider.fetchProfile` joins `user_org_memberships` for active org context (Phase 1: first membership; Phase 2: URL-based)

**Tests**
- New `_context.test.ts` — TDD tracer bullet for `getContext()`
- `_helpers.ts` — `seedContext` option auto-seeds the 2-call context mock; safe default for `maybeSingle`/`single`
- All existing tests updated to the new mock structure — 226/226 passing

## Acceptance criteria

- [x] `user_org_memberships` table with correct columns and RLS
- [x] `profiles.org_id/role/invite_status` removed
- [x] `user_departments.org_id` added
- [x] `get_my_org_ids()` returns all orgs for current user
- [x] All RLS policies use `= ANY(get_my_org_ids())`
- [x] `getContext()` resolves correct role and departmentIds from membership
- [x] Existing app functionality works for single-org users
- [x] 226/226 tests passing, TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)