### PR TITLE
refactor(invites): extract fulfillInvite helper, add acceptInviteAction tests

### DIFF
--- a/src/app/actions/__tests__/_helpers.ts
+++ b/src/app/actions/__tests__/_helpers.ts
@@ -43,6 +43,7 @@ export function makeClients(
     userId?: string
     email?: string
     inviteUserByEmail?: ReturnType<typeof vi.fn>
+    updateUserById?: ReturnType<typeof vi.fn>
     rpc?: ReturnType<typeof vi.fn>
     /**
      * Pre-seed the org-lookup, membership, and profile-name maybeSingle calls that
@@ -56,6 +57,7 @@ export function makeClients(
     userId = 'user-actor-0001',
     email = 'actor@example.com',
     inviteUserByEmail = vi.fn().mockResolvedValue({ error: null }),
+    updateUserById = vi.fn().mockResolvedValue({ error: null }),
     rpc = vi.fn().mockResolvedValue({ error: null }),
     seedContext = false,
   } = opts
@@ -78,7 +80,9 @@ export function makeClients(
     admin: {
       from: vi.fn().mockReturnValue(chain),
       rpc,
-      auth: { admin: { inviteUserByEmail, deleteUser: vi.fn().mockResolvedValue({}) } },
+      auth: {
+        admin: { inviteUserByEmail, updateUserById, deleteUser: vi.fn().mockResolvedValue({}) },
+      },
     } as unknown as NonNullable<ActionClients['admin']>,
   }
 }

--- a/src/app/actions/__tests__/invites.test.ts
+++ b/src/app/actions/__tests__/invites.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   acceptAuthenticatedInviteAction,
+  acceptInviteAction,
   acceptInviteViaGoogleAction,
   sendInviteAction,
 } from '../invites'
@@ -228,5 +229,106 @@ describe('acceptAuthenticatedInviteAction', () => {
     const result = await acceptAuthenticatedInviteAction('tok-xyz-789', clients)
 
     expect(result).toEqual({ orgSlug: 'acme' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// acceptInviteAction
+// ---------------------------------------------------------------------------
+
+describe('acceptInviteAction', () => {
+  it('returns null error and email on success', async () => {
+    const clients = makeClients(chain, { email: 'invited@example.com' })
+    chain.maybeSingle.mockResolvedValueOnce({ data: PENDING_INVITE })
+
+    const result = await acceptInviteAction('Alex Rivera', 'S3cur3Pass!', clients)
+
+    expect(result).toEqual({ error: null, email: 'invited@example.com' })
+    expect(chain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'user-actor-0001', org_id: 'org-0001', role: 'editor' })
+    )
+  })
+
+  it('returns error when no pending invite exists', async () => {
+    const clients = makeClients(chain, { email: 'noinvite@example.com' })
+    chain.maybeSingle.mockResolvedValueOnce({ data: null })
+
+    const result = await acceptInviteAction('Alex Rivera', 'S3cur3Pass!', clients)
+
+    expect(result).toEqual({
+      error: 'Invite not found or has expired. Ask your admin to resend it.',
+    })
+  })
+
+  it('returns error when session is missing', async () => {
+    const clients = makeClients(chain)
+    clients.supabase!.auth.getUser = vi.fn().mockResolvedValue({ data: { user: null } })
+
+    const result = await acceptInviteAction('Alex Rivera', 'S3cur3Pass!', clients)
+
+    expect(result).toEqual({ error: 'Session expired. Please use the invite link again.' })
+  })
+
+  it('returns error when password update fails', async () => {
+    const updateUserById = vi.fn().mockResolvedValue({ error: { message: 'weak password' } })
+    const clients = makeClients(chain, { email: 'invited@example.com', updateUserById })
+    chain.maybeSingle.mockResolvedValueOnce({ data: PENDING_INVITE })
+
+    const result = await acceptInviteAction('Alex Rivera', 'weak', clients)
+
+    expect(result).toEqual({ error: 'weak password' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fulfillInvite — error paths exercised through the accept actions
+// ---------------------------------------------------------------------------
+
+describe('fulfillInvite error paths', () => {
+  it('returns profile error when profile upsert fails', async () => {
+    const clients = makeClients(chain, { email: 'invited@example.com' })
+    chain.maybeSingle.mockResolvedValueOnce({ data: PENDING_INVITE })
+    chain.then.mockImplementationOnce((resolve: (v: unknown) => void) =>
+      resolve({ data: null, error: { message: 'profile write failed' } })
+    )
+
+    const result = await acceptInviteViaGoogleAction('Alex Rivera', clients)
+
+    expect(result).toEqual({ error: 'profile write failed' })
+  })
+
+  it('returns membership error when membership upsert fails', async () => {
+    const clients = makeClients(chain, { email: 'invited@example.com' })
+    chain.maybeSingle.mockResolvedValueOnce({ data: PENDING_INVITE })
+    chain.then
+      .mockImplementationOnce(
+        (resolve: (v: unknown) => void) => resolve({ data: null, error: null }) // profile upsert OK
+      )
+      .mockImplementationOnce((resolve: (v: unknown) => void) =>
+        resolve({ data: null, error: { message: 'membership write failed' } })
+      )
+
+    const result = await acceptInviteViaGoogleAction('Alex Rivera', clients)
+
+    expect(result).toEqual({ error: 'membership write failed' })
+  })
+
+  it('returns dept error when department insert fails', async () => {
+    const clients = makeClients(chain, { email: 'invited@example.com' })
+    chain.maybeSingle.mockResolvedValueOnce({ data: PENDING_INVITE })
+    chain.then
+      .mockImplementationOnce(
+        (resolve: (v: unknown) => void) => resolve({ data: null, error: null }) // profile OK
+      )
+      .mockImplementationOnce(
+        (resolve: (v: unknown) => void) => resolve({ data: null, error: null }) // membership OK
+      )
+      .mockImplementationOnce((resolve: (v: unknown) => void) =>
+        resolve({ data: null, error: { message: 'dept insert failed' } })
+      )
+
+    const result = await acceptInviteViaGoogleAction('Alex Rivera', clients)
+
+    expect(result).toEqual({ error: 'dept insert failed' })
   })
 })

--- a/src/app/actions/invites.ts
+++ b/src/app/actions/invites.ts
@@ -136,6 +136,55 @@ export async function sendInviteAction(
 }
 
 // ---------------------------------------------------------------------------
+// fulfillInvite — shared accept flow (profile + membership + departments + mark accepted)
+// ---------------------------------------------------------------------------
+
+type FulfillableInvite = {
+  id: string
+  org_id: string
+  role: string
+  department_ids: string[] | null
+}
+
+async function fulfillInvite(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string,
+  userEmail: string | undefined,
+  fullName: string,
+  invite: FulfillableInvite
+): Promise<{ error: string } | null> {
+  const { error: profileError } = await admin.from('profiles').upsert({
+    id: userId,
+    full_name: fullName,
+    email: userEmail,
+    updated_at: new Date().toISOString(),
+  })
+  if (profileError) return { error: profileError.message }
+
+  const { error: membershipError } = await admin.from('user_org_memberships').upsert({
+    user_id: userId,
+    org_id: invite.org_id,
+    role: invite.role,
+    invite_status: 'active',
+  })
+  if (membershipError) return { error: membershipError.message }
+
+  const deptIds = invite.department_ids ?? []
+  if (deptIds.length > 0) {
+    const { error: deptError } = await admin
+      .from('user_departments')
+      .insert(
+        deptIds.map((department_id) => ({ user_id: userId, department_id, org_id: invite.org_id }))
+      )
+    if (deptError) return { error: deptError.message }
+  }
+
+  await admin.from('invites').update({ accepted_at: new Date().toISOString() }).eq('id', invite.id)
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
 // acceptInviteViaGoogleAction
 // ---------------------------------------------------------------------------
 
@@ -153,7 +202,7 @@ export async function acceptInviteViaGoogleAction(
 
   const { data: invite } = await admin
     .from('invites')
-    .select('*')
+    .select('id, org_id, role, department_ids')
     .eq('email', user.email!.toLowerCase())
     .is('accepted_at', null)
     .gt('expires_at', new Date().toISOString())
@@ -161,40 +210,7 @@ export async function acceptInviteViaGoogleAction(
 
   if (!invite) return { error: 'Invite not found or has expired. Ask your admin to resend it.' }
 
-  const { error: profileError } = await admin.from('profiles').upsert({
-    id: user.id,
-    full_name: fullName,
-    email: user.email,
-    updated_at: new Date().toISOString(),
-  })
-  if (profileError) return { error: profileError.message }
-
-  const { error: membershipError } = await admin.from('user_org_memberships').upsert({
-    user_id: user.id,
-    org_id: invite.org_id,
-    role: invite.role as string,
-    invite_status: 'active',
-  })
-  if (membershipError) return { error: membershipError.message }
-
-  const deptIds = (invite.department_ids as string[] | null) ?? []
-  if (deptIds.length > 0) {
-    const { error: deptError } = await admin.from('user_departments').insert(
-      deptIds.map((department_id: string) => ({
-        user_id: user.id,
-        department_id,
-        org_id: invite.org_id,
-      }))
-    )
-    if (deptError) return { error: deptError.message }
-  }
-
-  await admin
-    .from('invites')
-    .update({ accepted_at: new Date().toISOString() })
-    .eq('id', invite.id as string)
-
-  return { error: null }
+  return (await fulfillInvite(admin, user.id, user.email, fullName, invite)) ?? { error: null }
 }
 
 // ---------------------------------------------------------------------------
@@ -203,19 +219,20 @@ export async function acceptInviteViaGoogleAction(
 
 export async function acceptInviteAction(
   fullName: string,
-  password: string
+  password: string,
+  clients?: ActionClients
 ): Promise<{ error: string } | { error: null; email: string }> {
-  const supabase = await createClient()
+  const supabase = clients?.supabase ?? (await createClient())
   const {
     data: { user },
   } = await supabase.auth.getUser()
   if (!user) return { error: 'Session expired. Please use the invite link again.' }
 
-  const admin = createAdminClient()
+  const admin = clients?.admin ?? createAdminClient()
 
   const { data: invite } = await admin
     .from('invites')
-    .select('*')
+    .select('id, org_id, role, department_ids')
     .eq('email', user.email!.toLowerCase())
     .is('accepted_at', null)
     .gt('expires_at', new Date().toISOString())
@@ -223,41 +240,11 @@ export async function acceptInviteAction(
 
   if (!invite) return { error: 'Invite not found or has expired. Ask your admin to resend it.' }
 
-  const { error: profileError } = await admin.from('profiles').upsert({
-    id: user.id,
-    full_name: fullName,
-    email: user.email,
-    updated_at: new Date().toISOString(),
-  })
-  if (profileError) return { error: profileError.message }
-
-  const { error: membershipError } = await admin.from('user_org_memberships').upsert({
-    user_id: user.id,
-    org_id: invite.org_id,
-    role: invite.role as string,
-    invite_status: 'active',
-  })
-  if (membershipError) return { error: membershipError.message }
-
   const { error: pwError } = await admin.auth.admin.updateUserById(user.id, { password })
   if (pwError) return { error: pwError.message }
 
-  const deptIds = (invite.department_ids as string[] | null) ?? []
-  if (deptIds.length > 0) {
-    const { error: deptError } = await admin.from('user_departments').insert(
-      deptIds.map((department_id: string) => ({
-        user_id: user.id,
-        department_id,
-        org_id: invite.org_id,
-      }))
-    )
-    if (deptError) return { error: deptError.message }
-  }
-
-  await admin
-    .from('invites')
-    .update({ accepted_at: new Date().toISOString() })
-    .eq('id', invite.id as string)
+  const result = await fulfillInvite(admin, user.id, user.email, fullName, invite)
+  if (result) return result
 
   return { error: null, email: user.email!.toLowerCase() }
 }
@@ -318,7 +305,7 @@ export async function acceptAuthenticatedInviteAction(
 
   const { data: invite } = await admin
     .from('invites')
-    .select('*, organizations(slug)')
+    .select('id, org_id, role, department_ids, email, organizations(slug)')
     .eq('token', token)
     .is('accepted_at', null)
     .gt('expires_at', new Date().toISOString())
@@ -333,38 +320,14 @@ export async function acceptAuthenticatedInviteAction(
   const fullName =
     (user.user_metadata?.full_name as string | undefined) ?? user.email!.split('@')[0]
 
-  const { error: profileError } = await admin.from('profiles').upsert({
-    id: user.id,
-    full_name: fullName,
-    email: user.email,
-    updated_at: new Date().toISOString(),
-  })
-  if (profileError) return { error: profileError.message }
-
-  const { error: membershipError } = await admin.from('user_org_memberships').upsert({
-    user_id: user.id,
-    org_id: invite.org_id,
-    role: invite.role as string,
-    invite_status: 'active',
-  })
-  if (membershipError) return { error: membershipError.message }
-
-  const deptIds = (invite.department_ids as string[] | null) ?? []
-  if (deptIds.length > 0) {
-    const { error: deptError } = await admin.from('user_departments').insert(
-      deptIds.map((department_id: string) => ({
-        user_id: user.id,
-        department_id,
-        org_id: invite.org_id,
-      }))
-    )
-    if (deptError) return { error: deptError.message }
-  }
-
-  await admin
-    .from('invites')
-    .update({ accepted_at: new Date().toISOString() })
-    .eq('id', invite.id as string)
+  const result = await fulfillInvite(
+    admin,
+    user.id,
+    user.email,
+    fullName,
+    invite as FulfillableInvite
+  )
+  if (result) return result
 
   const orgs = invite.organizations as { slug: string }[] | { slug: string } | null
   const orgSlug = (Array.isArray(orgs) ? orgs[0]?.slug : orgs?.slug) ?? ''


### PR DESCRIPTION
## Summary

- The 5-step accept flow (profile upsert → membership upsert → department insert → mark accepted) was copy-pasted verbatim into `acceptInviteViaGoogleAction`, `acceptInviteAction`, and `acceptAuthenticatedInviteAction`. Any bug fix had to be applied in three places.
- Extracted a private `fulfillInvite(admin, userId, userEmail, fullName, invite)` helper that owns the shared flow. Each accept action now handles only its own concern (invite lookup strategy, password setting, return shape) and delegates fulfillment to the helper.
- Added `clients?` to `acceptInviteAction` so it can be integration-tested without a real Supabase connection.
- Changed `select('*')` to explicit column lists in all invite lookups.

## Tests

- `acceptInviteAction` was previously untested — added 4 new cases (success, no invite, no session, password error)
- Added 3 `fulfillInvite` error-path cases (profile fail, membership fail, dept insert fail) exercised through `acceptInviteViaGoogleAction`
- Total: 253 tests passing (up from 246)

## Test plan
- [ ] New user accepts email invite → lands on dashboard with correct org membership
- [ ] Existing user accepts magic-link invite via confirm page → same result
- [ ] Google user accepts invite via `acceptInviteViaGoogleAction` → membership created

🤖 Generated with [Claude Code](https://claude.com/claude-code)