### PR TITLE
fix(checkout): fake applies full AssignmentPatch, add field-persistence test

### DIFF
--- a/src/lib/checkout/__tests__/checkout.test.ts
+++ b/src/lib/checkout/__tests__/checkout.test.ts
@@ -377,6 +377,29 @@ describe('updateAssignment', () => {
     expect(audit.calls[0]).toMatchObject({ action: 'updated', entityId: ASSET_ID })
   })
 
+  it('persists all patch fields — quantity, departmentId, locationId, notes', async () => {
+    const ports = makePorts(repo, audit)
+    await updateAssignment(
+      assignmentId,
+      ASSET_ID,
+      true,
+      makeInput({
+        assignedToName: 'Bob',
+        quantity: 2,
+        departmentId: 'dept-001',
+        locationId: 'loc-001',
+        notes: 'fragile',
+      }),
+      ports
+    )
+
+    const stored = repo.assignments.get(assignmentId)!
+    expect(stored.quantity).toBe(2)
+    expect(stored.departmentId).toBe('dept-001')
+    expect(stored.locationId).toBe('loc-001')
+    expect(stored.notes).toBe('fragile')
+  })
+
   it('allows quantity up to available + own allocation (bulk)', async () => {
     // 10 total, 4 by others, this assignment has 3 → max = 10 - 4 = 6
     const ports = makePorts(repo, audit)

--- a/src/lib/checkout/__tests__/fakes.ts
+++ b/src/lib/checkout/__tests__/fakes.ts
@@ -12,9 +12,18 @@ import type {
 // InMemoryCheckoutRepo
 // ---------------------------------------------------------------------------
 
+type StoredAssignment = CheckoutAssignmentRecord & {
+  asset: CheckoutAssetRecord
+  // Fields not in CheckoutAssignmentRecord but written by updateAssignmentFields
+  departmentId: string | null
+  locationId: string | null
+  expectedReturnAt: string | null
+  notes: string | null
+}
+
 export class InMemoryCheckoutRepo implements CheckoutRepository {
   assets = new Map<string, CheckoutAssetRecord>()
-  assignments = new Map<string, CheckoutAssignmentRecord & { asset: CheckoutAssetRecord }>()
+  assignments = new Map<string, StoredAssignment>()
   private nextId = 1
 
   seedAsset(asset: CheckoutAssetRecord & { id: string }) {
@@ -64,6 +73,10 @@ export class InMemoryCheckoutRepo implements CheckoutRepository {
       quantity: data.quantity,
       assignedToName: data.assignedToName,
       returnedAt: null,
+      departmentId: data.departmentId,
+      locationId: data.locationId,
+      expectedReturnAt: data.expectedReturnAt,
+      notes: data.notes,
       asset,
     })
     return { id }
@@ -94,7 +107,13 @@ export class InMemoryCheckoutRepo implements CheckoutRepository {
 
   async updateAssignmentFields(assignmentId: string, patch: AssignmentPatch) {
     const a = this.assignments.get(assignmentId)
-    if (a) a.assignedToName = patch.assignedToName
+    if (!a) return
+    a.assignedToName = patch.assignedToName
+    a.quantity = patch.quantity
+    a.departmentId = patch.departmentId
+    a.locationId = patch.locationId
+    a.expectedReturnAt = patch.expectedReturnAt
+    a.notes = patch.notes
   }
 
   async setAssetStatus(_assetId: string, _status: 'active' | 'checked_out') {


### PR DESCRIPTION
## Problem

`InMemoryCheckoutRepo.updateAssignmentFields` only applied `assignedToName` and silently ignored `quantity`, `departmentId`, `locationId`, `expectedReturnAt`, and `notes`. The Supabase adapter correctly writes all of them.

This meant domain tests for `updateAssignment` never verified that quantity, department, or location changes were persisted — those tests would pass even if the fields were completely dropped.

## Fix

- Extended the fake's internal `StoredAssignment` type to include the missing fields
- Updated `insertAssignment` to store all `InsertAssignmentData` fields (not just the ones in `CheckoutAssignmentRecord`)
- Fixed `updateAssignmentFields` to apply the full `AssignmentPatch`
- Added a test that explicitly asserts `quantity`, `departmentId`, `locationId`, and `notes` are all persisted after `updateAssignment`

## Result

254 tests passing (up from 253).

🤖 Generated with [Claude Code](https://claude.com/claude-code)