### PR TITLE
fix(seed): use extensions.crypt/gen_salt for hosted Supabase compatibility

### DIFF
--- a/supabase/seeds/001_initial_data.sql
+++ b/supabase/seeds/001_initial_data.sql
@@ -80,22 +80,22 @@ begin
     confirmation_token, recovery_token, email_change_token_new, email_change
   ) values
     ('00000000-0000-0000-0000-000000000000', u_owner, 'authenticated', 'authenticated',
-      'owner@acme.dev', crypt('Dev1234!', gen_salt('bf')),
+      'owner@acme.dev', extensions.crypt('Dev1234!', extensions.gen_salt('bf')),
       now(), '{"full_name":"Alex Rivera"}', '{"provider":"email","providers":["email"]}',
       now(), now(), '', '', '', ''),
 
     ('00000000-0000-0000-0000-000000000000', u_admin, 'authenticated', 'authenticated',
-      'admin@acme.dev', crypt('Dev1234!', gen_salt('bf')),
+      'admin@acme.dev', extensions.crypt('Dev1234!', extensions.gen_salt('bf')),
       now(), '{"full_name":"Sarah Mitchell"}', '{"provider":"email","providers":["email"]}',
       now(), now(), '', '', '', ''),
 
     ('00000000-0000-0000-0000-000000000000', u_editor, 'authenticated', 'authenticated',
-      'editor@acme.dev', crypt('Dev1234!', gen_salt('bf')),
+      'editor@acme.dev', extensions.crypt('Dev1234!', extensions.gen_salt('bf')),
       now(), '{"full_name":"James Thornton"}', '{"provider":"email","providers":["email"]}',
       now(), now(), '', '', '', ''),
 
     ('00000000-0000-0000-0000-000000000000', u_viewer, 'authenticated', 'authenticated',
-      'viewer@acme.dev', crypt('Dev1234!', gen_salt('bf')),
+      'viewer@acme.dev', extensions.crypt('Dev1234!', extensions.gen_salt('bf')),
       now(), '{"full_name":"Maria Chen"}', '{"provider":"email","providers":["email"]}',
       now(), now(), '', '', '', '');
 

--- a/supabase/seeds/003_multi_org.sql
+++ b/supabase/seeds/003_multi_org.sql
@@ -129,12 +129,12 @@ begin
     confirmation_token, recovery_token, email_change_token_new, email_change
   ) values
     ('00000000-0000-0000-0000-000000000000', u_user_d, 'authenticated', 'authenticated',
-      'newuser@dev.test', crypt('Dev1234!', gen_salt('bf')),
+      'newuser@dev.test', extensions.crypt('Dev1234!', extensions.gen_salt('bf')),
       now(), '{"full_name":"Dana Park"}', '{"provider":"email","providers":["email"]}',
       now(), now(), '', '', '', ''),
 
     ('00000000-0000-0000-0000-000000000000', u_user_f, 'authenticated', 'authenticated',
-      'soleowner@dev.test', crypt('Dev1234!', gen_salt('bf')),
+      'soleowner@dev.test', extensions.crypt('Dev1234!', extensions.gen_salt('bf')),
       now(), '{"full_name":"Frank Sole"}', '{"provider":"email","providers":["email"]}',
       now(), now(), '', '', '', '');
 


### PR DESCRIPTION
## Problem

`supabase db reset --linked` failed on hosted Supabase (both production and staging) with:

```
ERROR: function gen_salt(unknown) does not exist
```

Locally, `pgcrypto` is on the default search path so `gen_salt` resolves fine. On hosted Supabase, `pgcrypto` is installed in the `extensions` schema which isn't on the search path when seeds run.

## Fix

Prefixed all `crypt()` and `gen_salt()` calls in the seed files with `extensions.`:

```sql
-- before
crypt('Dev1234!', gen_salt('bf'))

-- after
extensions.crypt('Dev1234!', extensions.gen_salt('bf'))
```

Affected files: `001_initial_data.sql` (4 users), `003_multi_org.sql` (2 users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)