### PR TITLE
fix(org-settings): sync dept label to sidebar and clear unsaved bar on save

### DIFF
--- a/src/app/(app)/orgs/[slug]/settings/org/page.tsx
+++ b/src/app/(app)/orgs/[slug]/settings/org/page.tsx
@@ -341,7 +341,7 @@ function TransferOwnershipCard({ slug }: { slug: string }) {
 // ---------------------------------------------------------------------------
 
 export default function OrgSettingsPage() {
-  const { org, role } = useOrg()
+  const { org, role, refetchOrg } = useOrg()
   const { user } = useAuth()
   const router = useRouter()
   const { slug } = useParams<{ slug: string }>()
@@ -398,6 +398,8 @@ export default function OrgSettingsPage() {
       toast.error(result.error)
       return
     }
+    form.reset(data)
+    refetchOrg()
     router.refresh()
     toast.success('Organisation settings saved')
   }

--- a/src/providers/OrgProvider.tsx
+++ b/src/providers/OrgProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 
 import { createClient } from '@/lib/supabase/client'
 import type { OrgMembership, Organization, UserRole } from '@/lib/types'
@@ -15,6 +15,7 @@ type OrgContextValue = {
   role: UserRole | null
   departmentIds: string[]
   departmentNames: string[]
+  refetchOrg: () => void
 }
 
 const OrgContext = createContext<OrgContextValue | null>(null)
@@ -27,7 +28,7 @@ export function OrgProvider({ slug, children }: { slug: string; children: React.
   const membership = user?.memberships.find((m) => m.orgSlug === slug) ?? null
 
   // Fetch org data by slug
-  useEffect(() => {
+  const refetchOrg = useCallback(() => {
     if (!slug) return
     const supabase = createClient()
     supabase
@@ -53,6 +54,10 @@ export function OrgProvider({ slug, children }: { slug: string; children: React.
         })
       })
   }, [slug])
+
+  useEffect(() => {
+    refetchOrg()
+  }, [refetchOrg])
 
   // Fetch department names for the active membership (ids come from user_departments)
   const [departmentIds, setDepartmentIds] = useState<string[]>([])
@@ -92,6 +97,7 @@ export function OrgProvider({ slug, children }: { slug: string; children: React.
         role: membership?.role ?? null,
         departmentIds,
         departmentNames,
+        refetchOrg,
       }}
     >
       {children}
@@ -105,6 +111,7 @@ const DEFAULT_ORG_CONTEXT: OrgContextValue = {
   role: null,
   departmentIds: [],
   departmentNames: [],
+  refetchOrg: () => {},
 }
 
 export function useOrg(): OrgContextValue {


### PR DESCRIPTION
## Summary

- Expose `refetchOrg` from `OrgProvider` so callers can imperatively re-fetch org data (replaces the one-time `useEffect` with a `useCallback` + `useEffect` pattern)
- After a successful settings save, call `form.reset(data)` immediately to clear the dirty state (unsaved changes bar now disappears)
- Call `refetchOrg()` after save so the sidebar picks up the new department label without a full page reload

## Test plan

- [ ] Update the department label in org settings and hit Save — unsaved changes bar should disappear
- [ ] Confirm the sidebar nav item updates to the new label immediately after saving
- [ ] Confirm discarding changes still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)