### PR TITLE
feat(maintenance): schedule & view maintenance on asset detail page (#72)

### DIFF
--- a/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
@@ -10,6 +10,7 @@ import { deleteAsset, restockAsset, returnAsset, returnBulkAssignment } from '@/
 import { AssetStatusBadge } from '@/components/assets/AssetStatusBadge'
 import { CheckoutModal } from '@/components/assets/CheckoutModal'
 import { EditAssignmentModal } from '@/components/assets/EditAssignmentModal'
+import { MaintenanceTab } from '@/components/assets/MaintenanceTab'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -152,6 +153,7 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
           <TabsList>
             <TabsTrigger value="details">Details</TabsTrigger>
             <TabsTrigger value="assignment">{asset.ui.assignmentTabLabel}</TabsTrigger>
+            <TabsTrigger value="maintenance">Maintenance</TabsTrigger>
             <TabsTrigger value="history">History</TabsTrigger>
           </TabsList>
 
@@ -329,6 +331,16 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
                 This asset is not currently checked out.
               </div>
             )}
+          </TabsContent>
+
+          {/* Maintenance tab */}
+          <TabsContent value="maintenance" className="mt-4">
+            <MaintenanceTab
+              assetId={asset.id}
+              assetDepartmentId={asset.departmentId}
+              role={role}
+              departmentIds={departmentIds}
+            />
           </TabsContent>
 
           {/* History tab */}
@@ -541,6 +553,9 @@ const ACTION_LABELS: Record<AuditLog['action'], string> = {
   status_changed: 'Status changed',
   invited: 'Invited',
   role_changed: 'Role changed',
+  maintenance_scheduled: 'Maintenance scheduled',
+  maintenance_started: 'Maintenance started',
+  maintenance_completed: 'Maintenance completed',
 }
 
 const ACTION_COLORS: Record<AuditLog['action'], string> = {
@@ -552,6 +567,9 @@ const ACTION_COLORS: Record<AuditLog['action'], string> = {
   status_changed: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
   invited: 'bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400',
   role_changed: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-400',
+  maintenance_scheduled: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400',
+  maintenance_started: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  maintenance_completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
 }
 
 function AuditLogRow({ log, isLast }: { log: AuditLog; isLast: boolean }) {

--- a/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
@@ -338,6 +338,7 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
             <MaintenanceTab
               assetId={asset.id}
               assetDepartmentId={asset.departmentId}
+              isBulk={asset.isBulk}
               role={role}
               departmentIds={departmentIds}
             />

--- a/src/app/actions/maintenance.ts
+++ b/src/app/actions/maintenance.ts
@@ -1,0 +1,64 @@
+'use server'
+
+import {
+  logRetroactiveMaintenance,
+  scheduleMaintenance,
+  createSupabaseMaintenancePorts,
+} from '@/lib/maintenance'
+import { createPolicy } from '@/lib/permissions'
+import { MaintenanceFormSchema, type MaintenanceFormInput } from '@/lib/types/maintenance'
+
+import { getContext } from './_context'
+
+export async function scheduleMaintenanceAction(
+  orgSlug: string,
+  assetId: string,
+  assetDepartmentId: string | null,
+  input: MaintenanceFormInput
+): Promise<{ error: string } | null> {
+  const parsed = MaintenanceFormSchema.safeParse(input)
+  if (!parsed.success) return { error: parsed.error.issues[0].message }
+
+  const ctx = await getContext(orgSlug)
+  if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = createPolicy(ctx).enforce('maintenance:manage', {
+    departmentId: assetDepartmentId,
+  })
+  if (denied) return denied
+
+  const ports = createSupabaseMaintenancePorts(ctx)
+
+  if (parsed.data.isRetroactive) {
+    return logRetroactiveMaintenance(
+      ctx.orgId,
+      assetId,
+      {
+        title: parsed.data.title,
+        type: parsed.data.type,
+        scheduledDate: parsed.data.scheduledDate,
+        startedAt: parsed.data.startedAt!,
+        completedAt: parsed.data.completedAt!,
+        cost: parsed.data.cost,
+        technicianName: parsed.data.technicianName ?? null,
+        notes: parsed.data.notes ?? null,
+      },
+      ctx.userId,
+      ports
+    )
+  }
+
+  return scheduleMaintenance(
+    ctx.orgId,
+    assetId,
+    {
+      title: parsed.data.title,
+      type: parsed.data.type,
+      scheduledDate: parsed.data.scheduledDate,
+      technicianName: parsed.data.technicianName ?? null,
+      notes: parsed.data.notes ?? null,
+    },
+    ctx.userId,
+    ports
+  )
+}

--- a/src/app/actions/maintenance.ts
+++ b/src/app/actions/maintenance.ts
@@ -27,6 +27,19 @@ export async function scheduleMaintenanceAction(
   })
   if (denied) return denied
 
+  const { data: assetRow } = await ctx.admin
+    .from('assets')
+    .select('is_bulk')
+    .eq('id', assetId)
+    .eq('org_id', ctx.orgId)
+    .single()
+  if (assetRow?.is_bulk) {
+    return {
+      error:
+        'Maintenance cannot be scheduled for bulk assets. Track individual units as serialized assets.',
+    }
+  }
+
   const ports = createSupabaseMaintenancePorts(ctx)
 
   if (parsed.data.isRetroactive) {

--- a/src/components/assets/MaintenanceTab.tsx
+++ b/src/components/assets/MaintenanceTab.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { CalendarClock, Loader2, Plus, Wrench } from 'lucide-react'
+import { useState } from 'react'
+
+import { ScheduleMaintenanceModal } from '@/components/assets/ScheduleMaintenanceModal'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { useAssetMaintenanceEvents } from '@/lib/hooks/useMaintenance'
+import { createPolicy } from '@/lib/permissions'
+import type { UserRole } from '@/lib/types'
+import {
+  MAINTENANCE_STATUS_LABELS,
+  MAINTENANCE_TYPE_LABELS,
+  type MaintenanceEvent,
+} from '@/lib/types/maintenance'
+import { formatCurrency, formatDate } from '@/lib/utils/formatters'
+
+const STATUS_COLORS: Record<MaintenanceEvent['status'], string> = {
+  scheduled: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  in_progress: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+}
+
+interface MaintenanceTabProps {
+  assetId: string
+  assetDepartmentId: string | null
+  role: UserRole | null
+  departmentIds: string[]
+}
+
+export function MaintenanceTab({
+  assetId,
+  assetDepartmentId,
+  role,
+  departmentIds,
+}: MaintenanceTabProps) {
+  const { data: events, isLoading, refresh } = useAssetMaintenanceEvents(assetId)
+  const [scheduleOpen, setScheduleOpen] = useState(false)
+
+  const canManage = role
+    ? createPolicy({ role, departmentIds }).can('maintenance:manage', {
+        departmentId: assetDepartmentId,
+      })
+    : false
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-muted-foreground text-sm">
+          {events.length === 0
+            ? 'No maintenance history yet.'
+            : `${events.length} event${events.length !== 1 ? 's' : ''}`}
+        </p>
+        {canManage && (
+          <Button size="sm" onClick={() => setScheduleOpen(true)}>
+            <Plus className="mr-1.5 h-4 w-4" />
+            Schedule maintenance
+          </Button>
+        )}
+      </div>
+
+      {/* List */}
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+        </div>
+      ) : events.length === 0 ? (
+        <div className="text-muted-foreground flex flex-col items-center gap-2 rounded-xl border py-12 text-center text-sm">
+          <Wrench className="h-8 w-8 opacity-30" />
+          <p>No maintenance events recorded.</p>
+          {canManage && (
+            <Button variant="outline" size="sm" onClick={() => setScheduleOpen(true)}>
+              Schedule the first one
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {events.map((event) => (
+            <MaintenanceEventCard key={event.id} event={event} />
+          ))}
+        </div>
+      )}
+
+      {scheduleOpen && (
+        <ScheduleMaintenanceModal
+          assetId={assetId}
+          assetDepartmentId={assetDepartmentId}
+          open={scheduleOpen}
+          onOpenChange={setScheduleOpen}
+          onSuccess={refresh}
+        />
+      )}
+    </div>
+  )
+}
+
+function MaintenanceEventCard({ event }: { event: MaintenanceEvent }) {
+  return (
+    <Card className="shadow-sm">
+      <CardContent className="pt-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1 space-y-2">
+            {/* Title + badges */}
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-foreground font-medium">{event.title}</span>
+              <Badge variant="outline" className="text-xs">
+                {MAINTENANCE_TYPE_LABELS[event.type]}
+              </Badge>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[event.status]}`}
+              >
+                {MAINTENANCE_STATUS_LABELS[event.status]}
+              </span>
+            </div>
+
+            {/* Meta row */}
+            <div className="text-muted-foreground grid grid-cols-2 gap-x-6 gap-y-1 text-sm">
+              <span className="flex items-center gap-1">
+                <CalendarClock className="h-3.5 w-3.5" />
+                {formatDate(event.scheduledDate)}
+              </span>
+              {event.technicianName && <span>Technician: {event.technicianName}</span>}
+              {event.completedAt && <span>Completed: {formatDate(event.completedAt)}</span>}
+              {event.cost != null && <span>Cost: {formatCurrency(event.cost)}</span>}
+              {event.notes && <span className="col-span-2 truncate">Notes: {event.notes}</span>}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/assets/MaintenanceTab.tsx
+++ b/src/components/assets/MaintenanceTab.tsx
@@ -26,6 +26,7 @@ const STATUS_COLORS: Record<MaintenanceEvent['status'], string> = {
 interface MaintenanceTabProps {
   assetId: string
   assetDepartmentId: string | null
+  isBulk: boolean
   role: UserRole | null
   departmentIds: string[]
 }
@@ -33,6 +34,7 @@ interface MaintenanceTabProps {
 export function MaintenanceTab({
   assetId,
   assetDepartmentId,
+  isBulk,
   role,
   departmentIds,
 }: MaintenanceTabProps) {
@@ -44,6 +46,19 @@ export function MaintenanceTab({
         departmentId: assetDepartmentId,
       })
     : false
+
+  if (isBulk) {
+    return (
+      <div className="text-muted-foreground flex flex-col items-center gap-2 rounded-xl border py-12 text-center text-sm">
+        <Wrench className="h-8 w-8 opacity-30" />
+        <p className="font-medium">Maintenance is not tracked for bulk assets.</p>
+        <p className="max-w-xs">
+          To track maintenance per unit, create each item as a serialized asset with its own asset
+          tag.
+        </p>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-4">

--- a/src/components/assets/ScheduleMaintenanceModal.tsx
+++ b/src/components/assets/ScheduleMaintenanceModal.tsx
@@ -1,0 +1,300 @@
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+
+import { scheduleMaintenanceAction } from '@/app/actions/maintenance'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  MAINTENANCE_TYPE_LABELS,
+  MAINTENANCE_TYPES,
+  MaintenanceFormSchema,
+  type MaintenanceFormInput,
+} from '@/lib/types/maintenance'
+import { useOrg } from '@/providers/OrgProvider'
+
+interface ScheduleMaintenanceModalProps {
+  assetId: string
+  assetDepartmentId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+}
+
+export function ScheduleMaintenanceModal({
+  assetId,
+  assetDepartmentId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: ScheduleMaintenanceModalProps) {
+  const { membership } = useOrg()
+  const orgSlug = membership?.orgSlug ?? ''
+
+  const form = useForm<MaintenanceFormInput>({
+    resolver: zodResolver(MaintenanceFormSchema),
+    defaultValues: {
+      isRetroactive: false,
+      title: '',
+      type: 'preventive',
+      scheduledDate: '',
+      startedAt: null,
+      completedAt: null,
+      cost: null,
+      technicianName: null,
+      notes: null,
+    },
+  })
+
+  const isRetroactive = form.watch('isRetroactive')
+  const isSubmitting = form.formState.isSubmitting
+
+  async function onSubmit(data: MaintenanceFormInput) {
+    const result = await scheduleMaintenanceAction(orgSlug, assetId, assetDepartmentId, data)
+    if (result?.error) {
+      toast.error(result.error)
+      return
+    }
+    toast.success(data.isRetroactive ? 'Maintenance logged' : 'Maintenance scheduled')
+    form.reset()
+    onOpenChange(false)
+    onSuccess()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) form.reset()
+        onOpenChange(o)
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {isRetroactive ? 'Log past maintenance' : 'Schedule maintenance'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            {/* Retroactive toggle */}
+            <FormField
+              control={form.control}
+              name="isRetroactive"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                  <FormLabel className="cursor-pointer font-normal">
+                    Log past maintenance (already completed)
+                  </FormLabel>
+                </FormItem>
+              )}
+            />
+
+            {/* Title */}
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g. Annual inspection" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Type */}
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {MAINTENANCE_TYPES.map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {MAINTENANCE_TYPE_LABELS[t]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Scheduled date */}
+            <FormField
+              control={form.control}
+              name="scheduledDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{isRetroactive ? 'Planned date' : 'Scheduled date'}</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} value={field.value ?? ''} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Retroactive-only fields */}
+            {isRetroactive && (
+              <>
+                <div className="grid grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="startedAt"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Start date</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="date"
+                            {...field}
+                            value={field.value ?? ''}
+                            onChange={(e) => field.onChange(e.target.value || null)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="completedAt"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Completion date</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="date"
+                            {...field}
+                            value={field.value ?? ''}
+                            onChange={(e) => field.onChange(e.target.value || null)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name="cost"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Cost (optional)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={0}
+                          step={0.01}
+                          placeholder="0.00"
+                          value={field.value ?? ''}
+                          onChange={(e) =>
+                            field.onChange(e.target.value === '' ? null : Number(e.target.value))
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
+
+            {/* Technician */}
+            <FormField
+              control={form.control}
+              name="technicianName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Technician (optional)</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g. Bob Smith"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Notes */}
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Notes (optional)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="What needs to be done, or what was done..."
+                      rows={3}
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Saving…' : isRetroactive ? 'Log maintenance' : 'Schedule'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/dashboard/RecentActivity.tsx
+++ b/src/components/dashboard/RecentActivity.tsx
@@ -6,6 +6,7 @@ import {
   TrendingUp,
   UserCheck,
   UserPlus,
+  Wrench,
 } from 'lucide-react'
 import Link from 'next/link'
 
@@ -26,6 +27,9 @@ const ACTION_CONFIG: Record<
   status_changed: { label: 'Status changed', icon: TrendingUp, color: 'text-amber-500' },
   invited: { label: 'Invited', icon: UserPlus, color: 'text-teal-500' },
   role_changed: { label: 'Role changed', icon: UserCheck, color: 'text-indigo-500' },
+  maintenance_scheduled: { label: 'Maintenance scheduled', icon: Wrench, color: 'text-cyan-500' },
+  maintenance_started: { label: 'Maintenance started', icon: Wrench, color: 'text-amber-500' },
+  maintenance_completed: { label: 'Maintenance completed', icon: Wrench, color: 'text-green-500' },
 }
 
 interface RecentActivityProps {

--- a/src/lib/hooks/useMaintenance.ts
+++ b/src/lib/hooks/useMaintenance.ts
@@ -1,0 +1,58 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+
+import { createClient } from '@/lib/supabase/client'
+import type { MaintenanceEvent } from '@/lib/types/maintenance'
+import { useOrg } from '@/providers/OrgProvider'
+
+function mapEvent(r: Record<string, unknown>): MaintenanceEvent {
+  return {
+    id: r.id as string,
+    orgId: r.org_id as string,
+    assetId: r.asset_id as string,
+    title: r.title as string,
+    type: r.type as MaintenanceEvent['type'],
+    status: r.status as MaintenanceEvent['status'],
+    scheduledDate: r.scheduled_date as string,
+    startedAt: (r.started_at as string) ?? null,
+    completedAt: (r.completed_at as string) ?? null,
+    cost: (r.cost as number) ?? null,
+    technicianName: (r.technician_name as string) ?? null,
+    notes: (r.notes as string) ?? null,
+    createdBy: (r.created_by as string) ?? null,
+    deletedAt: (r.deleted_at as string) ?? null,
+    createdAt: r.created_at as string,
+    updatedAt: r.updated_at as string,
+  }
+}
+
+export function useAssetMaintenanceEvents(assetId: string): {
+  data: MaintenanceEvent[]
+  isLoading: boolean
+  refresh: () => void
+} {
+  const { org } = useOrg()
+  const orgId = org?.id ?? ''
+  const queryClient = useQueryClient()
+
+  const { data = [], isLoading } = useQuery({
+    queryKey: ['maintenanceEvents', assetId],
+    enabled: !!orgId && !!assetId,
+    queryFn: async () => {
+      const { data: rows } = await createClient()
+        .from('maintenance_events')
+        .select('*')
+        .eq('asset_id', assetId)
+        .is('deleted_at', null)
+        .order('created_at', { ascending: false })
+      return (rows ?? []).map(mapEvent)
+    },
+    staleTime: 30_000,
+  })
+
+  const refresh = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['maintenanceEvents', assetId] })
+  }, [queryClient, assetId])
+
+  return { data, isLoading, refresh }
+}

--- a/src/lib/types/audit.ts
+++ b/src/lib/types/audit.ts
@@ -13,6 +13,9 @@ export const AuditActionSchema = z.enum([
   'status_changed',
   'invited',
   'role_changed',
+  'maintenance_scheduled',
+  'maintenance_started',
+  'maintenance_completed',
 ])
 
 export type AuditAction = z.infer<typeof AuditActionSchema>

--- a/src/lib/types/maintenance.ts
+++ b/src/lib/types/maintenance.ts
@@ -50,3 +50,36 @@ export const MaintenanceEventSchema = z.object({
 })
 
 export type MaintenanceEvent = z.infer<typeof MaintenanceEventSchema>
+
+// ---------------------------------------------------------------------------
+// Form schemas
+// ---------------------------------------------------------------------------
+
+export const MaintenanceFormSchema = z
+  .object({
+    isRetroactive: z.boolean(),
+    title: z.string().min(1, 'Title is required').max(200),
+    type: MaintenanceTypeSchema,
+    scheduledDate: z.string().min(1, 'Scheduled date is required'),
+    startedAt: z.string().nullable(),
+    completedAt: z.string().nullable(),
+    cost: z.number().nonnegative('Cost must be 0 or more').nullable(),
+    technicianName: z.string().max(200).nullable(),
+    notes: z.string().max(2000).nullable(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.isRetroactive) {
+      if (!data.startedAt) {
+        ctx.addIssue({ code: 'custom', message: 'Start date is required', path: ['startedAt'] })
+      }
+      if (!data.completedAt) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Completion date is required',
+          path: ['completedAt'],
+        })
+      }
+    }
+  })
+
+export type MaintenanceFormInput = z.infer<typeof MaintenanceFormSchema>

--- a/supabase/seeds/004_maintenance.sql
+++ b/supabase/seeds/004_maintenance.sql
@@ -1,0 +1,128 @@
+-- ============================================================
+-- Seed 004: Maintenance events for Acme Corp
+--
+-- Creates a realistic spread of maintenance events across
+-- existing Acme Corp assets:
+--   - Several completed events with costs and notes
+--   - One in_progress event (drives the dashboard count)
+--   - Upcoming scheduled events (triggers dashboard card
+--     and checkout warning)
+-- ============================================================
+
+do $$
+declare
+  v_org_id uuid := '00000000-0000-0000-0000-000000000001';
+  u_admin  uuid := '00000000-0000-0000-0000-000000000012';
+  u_editor uuid := '00000000-0000-0000-0000-000000000013';
+
+  a_laptop1    uuid;
+  a_laptop2    uuid;
+  a_monitor    uuid;
+  a_phone      uuid;
+  a_projector  uuid;
+begin
+  -- ── CLEANUP ──────────────────────────────────────────────
+  delete from public.maintenance_events where org_id = v_org_id;
+
+  -- ── RESOLVE ASSET IDs BY TAG ─────────────────────────────
+  select id into a_laptop1   from public.assets where asset_tag = 'AT-0001' and org_id = v_org_id;
+  select id into a_laptop2   from public.assets where asset_tag = 'AT-0002' and org_id = v_org_id;
+  select id into a_monitor   from public.assets where asset_tag = 'AT-0006' and org_id = v_org_id;
+  select id into a_phone     from public.assets where asset_tag = 'AT-0011' and org_id = v_org_id;
+  select id into a_projector from public.assets where asset_tag = 'AT-0020' and org_id = v_org_id;
+
+  -- ── COMPLETED EVENTS ─────────────────────────────────────
+
+  -- Laptop 1: completed annual inspection (6 months ago)
+  if a_laptop1 is not null then
+    insert into public.maintenance_events (
+      org_id, asset_id, title, type, status,
+      scheduled_date, started_at, completed_at,
+      cost, technician_name, notes, created_by
+    ) values (
+      v_org_id, a_laptop1, 'Annual inspection', 'inspection', 'completed',
+      current_date - interval '6 months',
+      current_date - interval '6 months',
+      current_date - interval '6 months' + interval '2 hours',
+      0, 'IT Team', 'Passed all checks. Battery at 87% health.', u_admin
+    );
+  end if;
+
+  -- Laptop 2: completed screen replacement (3 months ago)
+  if a_laptop2 is not null then
+    insert into public.maintenance_events (
+      org_id, asset_id, title, type, status,
+      scheduled_date, started_at, completed_at,
+      cost, technician_name, notes, created_by
+    ) values (
+      v_org_id, a_laptop2, 'Screen replacement', 'corrective', 'completed',
+      current_date - interval '3 months',
+      current_date - interval '3 months',
+      current_date - interval '3 months' + interval '4 hours',
+      350.00, 'Bob Walsh', 'Replaced cracked LCD panel. Tested — no dead pixels.', u_admin
+    );
+  end if;
+
+  -- Monitor: completed calibration (2 months ago)
+  if a_monitor is not null then
+    insert into public.maintenance_events (
+      org_id, asset_id, title, type, status,
+      scheduled_date, started_at, completed_at,
+      cost, technician_name, notes, created_by
+    ) values (
+      v_org_id, a_monitor, 'Display calibration', 'preventive', 'completed',
+      current_date - interval '2 months',
+      current_date - interval '2 months',
+      current_date - interval '2 months' + interval '1 hour',
+      75.00, 'IT Team', 'Calibrated color profile. Delta-E now within acceptable range.', u_editor
+    );
+  end if;
+
+  -- ── IN_PROGRESS EVENT (drives dashboard under_maintenance count) ──
+
+  -- Phone: currently in_progress repair — also set asset status
+  if a_phone is not null then
+    insert into public.maintenance_events (
+      org_id, asset_id, title, type, status,
+      scheduled_date, started_at,
+      technician_name, notes, created_by
+    ) values (
+      v_org_id, a_phone, 'Battery replacement', 'corrective', 'in_progress',
+      current_date - interval '1 day',
+      current_date - interval '1 day',
+      'Bob Walsh', 'Battery swelling detected. Replacement ordered.', u_admin
+    );
+
+    update public.assets
+      set status = 'under_maintenance'
+      where id = a_phone and org_id = v_org_id;
+  end if;
+
+  -- ── SCHEDULED EVENTS (upcoming — triggers dashboard card + checkout warning) ──
+
+  -- Laptop 1: upcoming preventive maintenance next week
+  if a_laptop1 is not null then
+    insert into public.maintenance_events (
+      org_id, asset_id, title, type, status,
+      scheduled_date, technician_name, notes, created_by
+    ) values (
+      v_org_id, a_laptop1, 'Quarterly checkup', 'preventive', 'scheduled',
+      current_date + interval '7 days',
+      'IT Team', 'Routine quarterly health check.', u_admin
+    );
+  end if;
+
+  -- Projector: upcoming inspection in 2 weeks
+  if a_projector is not null then
+    insert into public.maintenance_events (
+      org_id, asset_id, title, type, status,
+      scheduled_date, notes, created_by
+    ) values (
+      v_org_id, a_projector, 'Lamp hours inspection', 'inspection', 'scheduled',
+      current_date + interval '14 days',
+      'Check lamp hours and clean filter.', u_editor
+    );
+  end if;
+
+end;
+$$;


### PR DESCRIPTION
## Summary

- Adds **Schedule maintenance** modal to the asset detail page (editor+ only), supporting both upcoming and retroactive entries
- Adds **Maintenance tab** on asset detail with event list, status/type badges, technician, cost, and notes
- Wires `scheduleMaintenanceAction` server action through the domain layer (`scheduleMaintenance` / `logRetroactiveMaintenance`)
- Adds `useAssetMaintenanceEvents` React Query hook for the tab
- Extends `AuditAction` type and `RecentActivity` dashboard component with maintenance action entries
- Adds `supabase/seeds/004_maintenance.sql` with realistic completed, in-progress, and scheduled events

## Test plan

- [ ] Run `pnpm db:reset` — seed creates events visible on AT-0001, AT-0002, AT-0006, AT-0011, AT-0020
- [ ] Open asset detail for any seeded asset → Maintenance tab shows events
- [ ] As admin/editor: click "Schedule maintenance" → fill form → event appears in list
- [ ] Check "Log past maintenance" → start/completion date fields appear and are required
- [ ] As viewer: "Schedule maintenance" button is not visible
- [ ] Asset AT-0011 shows "In Progress" battery replacement event

🤖 Generated with [Claude Code](https://claude.com/claude-code)