### PR TITLE
feat(maintenance): start/complete status transitions on asset detail (#73)

### DIFF
--- a/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
@@ -341,6 +341,7 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
               isBulk={asset.isBulk}
               role={role}
               departmentIds={departmentIds}
+              onAssetRefresh={refresh}
             />
           </TabsContent>
 

--- a/src/app/actions/maintenance.ts
+++ b/src/app/actions/maintenance.ts
@@ -1,12 +1,19 @@
 'use server'
 
 import {
+  completeMaintenance,
+  createSupabaseMaintenancePorts,
   logRetroactiveMaintenance,
   scheduleMaintenance,
-  createSupabaseMaintenancePorts,
+  startMaintenance,
 } from '@/lib/maintenance'
 import { createPolicy } from '@/lib/permissions'
-import { MaintenanceFormSchema, type MaintenanceFormInput } from '@/lib/types/maintenance'
+import {
+  CompleteMaintenanceFormSchema,
+  MaintenanceFormSchema,
+  type CompleteMaintenanceFormInput,
+  type MaintenanceFormInput,
+} from '@/lib/types/maintenance'
 
 import { getContext } from './_context'
 
@@ -74,4 +81,40 @@ export async function scheduleMaintenanceAction(
     ctx.userId,
     ports
   )
+}
+
+export async function startMaintenanceAction(
+  orgSlug: string,
+  eventId: string,
+  assetDepartmentId: string | null
+): Promise<{ error: string } | null> {
+  const ctx = await getContext(orgSlug)
+  if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = createPolicy(ctx).enforce('maintenance:manage', {
+    departmentId: assetDepartmentId,
+  })
+  if (denied) return denied
+
+  return startMaintenance(eventId, createSupabaseMaintenancePorts(ctx))
+}
+
+export async function completeMaintenanceAction(
+  orgSlug: string,
+  eventId: string,
+  assetDepartmentId: string | null,
+  input: CompleteMaintenanceFormInput
+): Promise<{ error: string } | null> {
+  const parsed = CompleteMaintenanceFormSchema.safeParse(input)
+  if (!parsed.success) return { error: parsed.error.issues[0].message }
+
+  const ctx = await getContext(orgSlug)
+  if (!ctx) return { error: 'Not authenticated' }
+
+  const denied = createPolicy(ctx).enforce('maintenance:manage', {
+    departmentId: assetDepartmentId,
+  })
+  if (denied) return denied
+
+  return completeMaintenance(eventId, parsed.data, createSupabaseMaintenancePorts(ctx))
 }

--- a/src/app/actions/maintenance.ts
+++ b/src/app/actions/maintenance.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { revalidatePath } from 'next/cache'
+
 import {
   completeMaintenance,
   createSupabaseMaintenancePorts,
@@ -85,6 +87,7 @@ export async function scheduleMaintenanceAction(
 
 export async function startMaintenanceAction(
   orgSlug: string,
+  assetId: string,
   eventId: string,
   assetDepartmentId: string | null
 ): Promise<{ error: string } | null> {
@@ -96,11 +99,14 @@ export async function startMaintenanceAction(
   })
   if (denied) return denied
 
-  return startMaintenance(eventId, createSupabaseMaintenancePorts(ctx))
+  const result = await startMaintenance(eventId, createSupabaseMaintenancePorts(ctx))
+  if (!result) revalidatePath(`/orgs/${orgSlug}/assets/${assetId}`)
+  return result
 }
 
 export async function completeMaintenanceAction(
   orgSlug: string,
+  assetId: string,
   eventId: string,
   assetDepartmentId: string | null,
   input: CompleteMaintenanceFormInput
@@ -116,5 +122,11 @@ export async function completeMaintenanceAction(
   })
   if (denied) return denied
 
-  return completeMaintenance(eventId, parsed.data, createSupabaseMaintenancePorts(ctx))
+  const result = await completeMaintenance(
+    eventId,
+    parsed.data,
+    createSupabaseMaintenancePorts(ctx)
+  )
+  if (!result) revalidatePath(`/orgs/${orgSlug}/assets/${assetId}`)
+  return result
 }

--- a/src/app/actions/maintenance.ts
+++ b/src/app/actions/maintenance.ts
@@ -1,7 +1,5 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
-
 import {
   completeMaintenance,
   createSupabaseMaintenancePorts,
@@ -87,7 +85,6 @@ export async function scheduleMaintenanceAction(
 
 export async function startMaintenanceAction(
   orgSlug: string,
-  assetId: string,
   eventId: string,
   assetDepartmentId: string | null
 ): Promise<{ error: string } | null> {
@@ -99,14 +96,11 @@ export async function startMaintenanceAction(
   })
   if (denied) return denied
 
-  const result = await startMaintenance(eventId, createSupabaseMaintenancePorts(ctx))
-  if (!result) revalidatePath(`/orgs/${orgSlug}/assets/${assetId}`)
-  return result
+  return startMaintenance(eventId, createSupabaseMaintenancePorts(ctx))
 }
 
 export async function completeMaintenanceAction(
   orgSlug: string,
-  assetId: string,
   eventId: string,
   assetDepartmentId: string | null,
   input: CompleteMaintenanceFormInput
@@ -122,11 +116,5 @@ export async function completeMaintenanceAction(
   })
   if (denied) return denied
 
-  const result = await completeMaintenance(
-    eventId,
-    parsed.data,
-    createSupabaseMaintenancePorts(ctx)
-  )
-  if (!result) revalidatePath(`/orgs/${orgSlug}/assets/${assetId}`)
-  return result
+  return completeMaintenance(eventId, parsed.data, createSupabaseMaintenancePorts(ctx))
 }

--- a/src/components/assets/CompleteMaintenanceModal.tsx
+++ b/src/components/assets/CompleteMaintenanceModal.tsx
@@ -31,6 +31,7 @@ import { useOrg } from '@/providers/OrgProvider'
 
 interface CompleteMaintenanceModalProps {
   eventId: string
+  assetId: string
   assetDepartmentId: string | null
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -39,6 +40,7 @@ interface CompleteMaintenanceModalProps {
 
 export function CompleteMaintenanceModal({
   eventId,
+  assetId,
   assetDepartmentId,
   open,
   onOpenChange,
@@ -60,7 +62,13 @@ export function CompleteMaintenanceModal({
   const isSubmitting = form.formState.isSubmitting
 
   async function onSubmit(data: CompleteMaintenanceFormInput) {
-    const result = await completeMaintenanceAction(orgSlug, eventId, assetDepartmentId, data)
+    const result = await completeMaintenanceAction(
+      orgSlug,
+      assetId,
+      eventId,
+      assetDepartmentId,
+      data
+    )
     if (result?.error) {
       toast.error(result.error)
       return

--- a/src/components/assets/CompleteMaintenanceModal.tsx
+++ b/src/components/assets/CompleteMaintenanceModal.tsx
@@ -31,7 +31,6 @@ import { useOrg } from '@/providers/OrgProvider'
 
 interface CompleteMaintenanceModalProps {
   eventId: string
-  assetId: string
   assetDepartmentId: string | null
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -40,7 +39,6 @@ interface CompleteMaintenanceModalProps {
 
 export function CompleteMaintenanceModal({
   eventId,
-  assetId,
   assetDepartmentId,
   open,
   onOpenChange,
@@ -62,13 +60,7 @@ export function CompleteMaintenanceModal({
   const isSubmitting = form.formState.isSubmitting
 
   async function onSubmit(data: CompleteMaintenanceFormInput) {
-    const result = await completeMaintenanceAction(
-      orgSlug,
-      assetId,
-      eventId,
-      assetDepartmentId,
-      data
-    )
+    const result = await completeMaintenanceAction(orgSlug, eventId, assetDepartmentId, data)
     if (result?.error) {
       toast.error(result.error)
       return

--- a/src/components/assets/CompleteMaintenanceModal.tsx
+++ b/src/components/assets/CompleteMaintenanceModal.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+
+import { completeMaintenanceAction } from '@/app/actions/maintenance'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  CompleteMaintenanceFormSchema,
+  type CompleteMaintenanceFormInput,
+} from '@/lib/types/maintenance'
+import { useOrg } from '@/providers/OrgProvider'
+
+interface CompleteMaintenanceModalProps {
+  eventId: string
+  assetDepartmentId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+}
+
+export function CompleteMaintenanceModal({
+  eventId,
+  assetDepartmentId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: CompleteMaintenanceModalProps) {
+  const { membership } = useOrg()
+  const orgSlug = membership?.orgSlug ?? ''
+
+  const form = useForm<CompleteMaintenanceFormInput>({
+    resolver: zodResolver(CompleteMaintenanceFormSchema),
+    defaultValues: {
+      completedAt: new Date().toISOString().slice(0, 10),
+      cost: null,
+      technicianName: null,
+      notes: null,
+    },
+  })
+
+  const isSubmitting = form.formState.isSubmitting
+
+  async function onSubmit(data: CompleteMaintenanceFormInput) {
+    const result = await completeMaintenanceAction(orgSlug, eventId, assetDepartmentId, data)
+    if (result?.error) {
+      toast.error(result.error)
+      return
+    }
+    toast.success('Maintenance completed')
+    form.reset()
+    onOpenChange(false)
+    onSuccess()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) form.reset()
+        onOpenChange(o)
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Complete maintenance</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="completedAt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Completion date</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="cost"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Cost (optional)</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={0}
+                      step={0.01}
+                      placeholder="0.00"
+                      value={field.value ?? ''}
+                      onChange={(e) =>
+                        field.onChange(e.target.value === '' ? null : Number(e.target.value))
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="technicianName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Technician (optional)</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g. Bob Smith"
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Notes (optional)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="What was done, parts replaced, findings..."
+                      rows={3}
+                      {...field}
+                      value={field.value ?? ''}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Saving…' : 'Mark completed'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/assets/MaintenanceTab.tsx
+++ b/src/components/assets/MaintenanceTab.tsx
@@ -1,8 +1,12 @@
 'use client'
 
-import { CalendarClock, Loader2, Plus, Wrench } from 'lucide-react'
+import { CalendarClock, Loader2, Play, Plus, Wrench } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { toast } from 'sonner'
 
+import { startMaintenanceAction } from '@/app/actions/maintenance'
+import { CompleteMaintenanceModal } from '@/components/assets/CompleteMaintenanceModal'
 import { ScheduleMaintenanceModal } from '@/components/assets/ScheduleMaintenanceModal'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -16,6 +20,7 @@ import {
   type MaintenanceEvent,
 } from '@/lib/types/maintenance'
 import { formatCurrency, formatDate } from '@/lib/utils/formatters'
+import { useOrg } from '@/providers/OrgProvider'
 
 const STATUS_COLORS: Record<MaintenanceEvent['status'], string> = {
   scheduled: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
@@ -38,6 +43,7 @@ export function MaintenanceTab({
   role,
   departmentIds,
 }: MaintenanceTabProps) {
+  const router = useRouter()
   const { data: events, isLoading, refresh } = useAssetMaintenanceEvents(assetId)
   const [scheduleOpen, setScheduleOpen] = useState(false)
 
@@ -46,6 +52,11 @@ export function MaintenanceTab({
         departmentId: assetDepartmentId,
       })
     : false
+
+  function handleSuccess() {
+    refresh()
+    router.refresh()
+  }
 
   if (isBulk) {
     return (
@@ -95,7 +106,13 @@ export function MaintenanceTab({
       ) : (
         <div className="space-y-3">
           {events.map((event) => (
-            <MaintenanceEventCard key={event.id} event={event} />
+            <MaintenanceEventCard
+              key={event.id}
+              event={event}
+              assetDepartmentId={assetDepartmentId}
+              canManage={canManage}
+              onSuccess={handleSuccess}
+            />
           ))}
         </div>
       )}
@@ -106,14 +123,43 @@ export function MaintenanceTab({
           assetDepartmentId={assetDepartmentId}
           open={scheduleOpen}
           onOpenChange={setScheduleOpen}
-          onSuccess={refresh}
+          onSuccess={handleSuccess}
         />
       )}
     </div>
   )
 }
 
-function MaintenanceEventCard({ event }: { event: MaintenanceEvent }) {
+interface MaintenanceEventCardProps {
+  event: MaintenanceEvent
+  assetDepartmentId: string | null
+  canManage: boolean
+  onSuccess: () => void
+}
+
+function MaintenanceEventCard({
+  event,
+  assetDepartmentId,
+  canManage,
+  onSuccess,
+}: MaintenanceEventCardProps) {
+  const { membership } = useOrg()
+  const orgSlug = membership?.orgSlug ?? ''
+  const [completeOpen, setCompleteOpen] = useState(false)
+  const [starting, setStarting] = useState(false)
+
+  async function handleStart() {
+    setStarting(true)
+    const result = await startMaintenanceAction(orgSlug, event.id, assetDepartmentId)
+    setStarting(false)
+    if (result?.error) {
+      toast.error(result.error)
+      return
+    }
+    toast.success('Maintenance started')
+    onSuccess()
+  }
+
   return (
     <Card className="shadow-sm">
       <CardContent className="pt-4">
@@ -144,6 +190,33 @@ function MaintenanceEventCard({ event }: { event: MaintenanceEvent }) {
               {event.notes && <span className="col-span-2 truncate">Notes: {event.notes}</span>}
             </div>
           </div>
+
+          {/* Action buttons */}
+          {canManage && event.status === 'scheduled' && (
+            <Button size="sm" variant="outline" onClick={handleStart} disabled={starting}>
+              {starting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Play className="h-3.5 w-3.5" />
+              )}
+              <span className="ml-1.5">Start</span>
+            </Button>
+          )}
+          {canManage && event.status === 'in_progress' && (
+            <>
+              <Button size="sm" variant="outline" onClick={() => setCompleteOpen(true)}>
+                <Wrench className="h-3.5 w-3.5" />
+                <span className="ml-1.5">Complete</span>
+              </Button>
+              <CompleteMaintenanceModal
+                eventId={event.id}
+                assetDepartmentId={assetDepartmentId}
+                open={completeOpen}
+                onOpenChange={setCompleteOpen}
+                onSuccess={onSuccess}
+              />
+            </>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/src/components/assets/MaintenanceTab.tsx
+++ b/src/components/assets/MaintenanceTab.tsx
@@ -109,7 +109,6 @@ export function MaintenanceTab({
             <MaintenanceEventCard
               key={event.id}
               event={event}
-              assetId={assetId}
               assetDepartmentId={assetDepartmentId}
               canManage={canManage}
               onSuccess={handleTransitionSuccess}
@@ -133,7 +132,6 @@ export function MaintenanceTab({
 
 interface MaintenanceEventCardProps {
   event: MaintenanceEvent
-  assetId: string
   assetDepartmentId: string | null
   canManage: boolean
   onSuccess: () => void
@@ -141,7 +139,6 @@ interface MaintenanceEventCardProps {
 
 function MaintenanceEventCard({
   event,
-  assetId,
   assetDepartmentId,
   canManage,
   onSuccess,
@@ -153,7 +150,7 @@ function MaintenanceEventCard({
 
   async function handleStart() {
     setStarting(true)
-    const result = await startMaintenanceAction(orgSlug, assetId, event.id, assetDepartmentId)
+    const result = await startMaintenanceAction(orgSlug, event.id, assetDepartmentId)
     setStarting(false)
     if (result?.error) {
       toast.error(result.error)
@@ -213,7 +210,6 @@ function MaintenanceEventCard({
               </Button>
               <CompleteMaintenanceModal
                 eventId={event.id}
-                assetId={assetId}
                 assetDepartmentId={assetDepartmentId}
                 open={completeOpen}
                 onOpenChange={setCompleteOpen}

--- a/src/components/assets/MaintenanceTab.tsx
+++ b/src/components/assets/MaintenanceTab.tsx
@@ -33,6 +33,7 @@ interface MaintenanceTabProps {
   isBulk: boolean
   role: UserRole | null
   departmentIds: string[]
+  onAssetRefresh: () => void
 }
 
 export function MaintenanceTab({
@@ -41,6 +42,7 @@ export function MaintenanceTab({
   isBulk,
   role,
   departmentIds,
+  onAssetRefresh,
 }: MaintenanceTabProps) {
   const { data: events, isLoading, refresh } = useAssetMaintenanceEvents(assetId)
   const [scheduleOpen, setScheduleOpen] = useState(false)
@@ -50,6 +52,11 @@ export function MaintenanceTab({
         departmentId: assetDepartmentId,
       })
     : false
+
+  function handleTransitionSuccess() {
+    refresh()
+    onAssetRefresh()
+  }
 
   if (isBulk) {
     return (
@@ -105,7 +112,7 @@ export function MaintenanceTab({
               assetId={assetId}
               assetDepartmentId={assetDepartmentId}
               canManage={canManage}
-              onSuccess={refresh}
+              onSuccess={handleTransitionSuccess}
             />
           ))}
         </div>

--- a/src/components/assets/MaintenanceTab.tsx
+++ b/src/components/assets/MaintenanceTab.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { CalendarClock, Loader2, Play, Plus, Wrench } from 'lucide-react'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
@@ -43,7 +42,6 @@ export function MaintenanceTab({
   role,
   departmentIds,
 }: MaintenanceTabProps) {
-  const router = useRouter()
   const { data: events, isLoading, refresh } = useAssetMaintenanceEvents(assetId)
   const [scheduleOpen, setScheduleOpen] = useState(false)
 
@@ -52,11 +50,6 @@ export function MaintenanceTab({
         departmentId: assetDepartmentId,
       })
     : false
-
-  function handleSuccess() {
-    refresh()
-    router.refresh()
-  }
 
   if (isBulk) {
     return (
@@ -109,9 +102,10 @@ export function MaintenanceTab({
             <MaintenanceEventCard
               key={event.id}
               event={event}
+              assetId={assetId}
               assetDepartmentId={assetDepartmentId}
               canManage={canManage}
-              onSuccess={handleSuccess}
+              onSuccess={refresh}
             />
           ))}
         </div>
@@ -123,7 +117,7 @@ export function MaintenanceTab({
           assetDepartmentId={assetDepartmentId}
           open={scheduleOpen}
           onOpenChange={setScheduleOpen}
-          onSuccess={handleSuccess}
+          onSuccess={refresh}
         />
       )}
     </div>
@@ -132,6 +126,7 @@ export function MaintenanceTab({
 
 interface MaintenanceEventCardProps {
   event: MaintenanceEvent
+  assetId: string
   assetDepartmentId: string | null
   canManage: boolean
   onSuccess: () => void
@@ -139,6 +134,7 @@ interface MaintenanceEventCardProps {
 
 function MaintenanceEventCard({
   event,
+  assetId,
   assetDepartmentId,
   canManage,
   onSuccess,
@@ -150,7 +146,7 @@ function MaintenanceEventCard({
 
   async function handleStart() {
     setStarting(true)
-    const result = await startMaintenanceAction(orgSlug, event.id, assetDepartmentId)
+    const result = await startMaintenanceAction(orgSlug, assetId, event.id, assetDepartmentId)
     setStarting(false)
     if (result?.error) {
       toast.error(result.error)
@@ -210,6 +206,7 @@ function MaintenanceEventCard({
               </Button>
               <CompleteMaintenanceModal
                 eventId={event.id}
+                assetId={assetId}
                 assetDepartmentId={assetDepartmentId}
                 open={completeOpen}
                 onOpenChange={setCompleteOpen}

--- a/src/lib/types/maintenance.ts
+++ b/src/lib/types/maintenance.ts
@@ -83,3 +83,12 @@ export const MaintenanceFormSchema = z
   })
 
 export type MaintenanceFormInput = z.infer<typeof MaintenanceFormSchema>
+
+export const CompleteMaintenanceFormSchema = z.object({
+  completedAt: z.string().min(1, 'Completion date is required'),
+  cost: z.number().nonnegative('Cost must be 0 or more').nullable(),
+  technicianName: z.string().max(200).nullable(),
+  notes: z.string().max(2000).nullable(),
+})
+
+export type CompleteMaintenanceFormInput = z.infer<typeof CompleteMaintenanceFormSchema>


### PR DESCRIPTION
## Summary

- **Start** button on `scheduled` events — calls `startMaintenanceAction`, transitions event to `in_progress` and sets asset status to `under_maintenance`
- **Complete** button on `in_progress` events — opens `CompleteMaintenanceModal` to capture completion date, cost, technician, and notes; calls `completeMaintenanceAction`, transitions event to `completed` and restores asset to `active`
- Both actions are permission-gated (`maintenance:manage`, department-scoped)
- `router.refresh()` called after each transition so the asset status badge in the page header updates without a manual reload
- `CompleteMaintenanceFormSchema` added to maintenance types

## Test plan

- [ ] Run `pnpm db:reset` — AT-0011 (phone) has an `in_progress` event visible on its Maintenance tab
- [ ] Open a `scheduled` event (AT-0001 or AT-0020) → "Start" button appears for editor+, click it → event transitions to In Progress, asset status badge updates to "Under Maintenance"
- [ ] On the in_progress event → "Complete" button opens modal → fill completion date → submit → event moves to Completed, asset status returns to Active
- [ ] As viewer: no Start or Complete buttons visible
- [ ] Completing an event that was concurrently checked out does not overwrite `checked_out` status (domain guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)