### PR TITLE
feat(maintenance): global maintenance list page (#75)

### DIFF
--- a/src/app/(app)/orgs/[slug]/maintenance/page.tsx
+++ b/src/app/(app)/orgs/[slug]/maintenance/page.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { CalendarClock, Loader2, Wrench } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
+
+import { EmptyState } from '@/components/shared/EmptyState'
+import { PageHeader } from '@/components/shared/PageHeader'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  type MaintenanceListFilters,
+  type MaintenanceListItem,
+  useMaintenanceList,
+} from '@/lib/hooks/useMaintenance'
+import {
+  MAINTENANCE_STATUSES,
+  MAINTENANCE_STATUS_LABELS,
+  MAINTENANCE_TYPE_LABELS,
+} from '@/lib/types/maintenance'
+import { formatCurrency, formatDate } from '@/lib/utils/formatters'
+import { useOrg } from '@/providers/OrgProvider'
+
+const STATUS_COLORS: Record<MaintenanceListItem['status'], string> = {
+  scheduled: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  in_progress: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+}
+
+export default function MaintenancePage() {
+  const { membership } = useOrg()
+  const orgSlug = membership?.orgSlug ?? ''
+
+  const [filters, setFilters] = useState<MaintenanceListFilters>({})
+  const { data: events, isLoading } = useMaintenanceList(filters)
+
+  function handleStatusChange(value: string) {
+    setFilters((f) => ({
+      ...f,
+      status: value === '__all__' ? '' : (value as MaintenanceListFilters['status']),
+    }))
+  }
+
+  function handleDateFromChange(value: string) {
+    setFilters((f) => ({ ...f, dateFrom: value || undefined }))
+  }
+
+  function handleDateToChange(value: string) {
+    setFilters((f) => ({ ...f, dateTo: value || undefined }))
+  }
+
+  const hasFilters = !!filters.status || !!filters.dateFrom || !!filters.dateTo
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Maintenance"
+        description={
+          isLoading ? 'Loading…' : `${events.length} event${events.length !== 1 ? 's' : ''}`
+        }
+      />
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Select value={filters.status || '__all__'} onValueChange={handleStatusChange}>
+          <SelectTrigger className="w-36">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All statuses</SelectItem>
+            {MAINTENANCE_STATUSES.map((s) => (
+              <SelectItem key={s} value={s}>
+                {MAINTENANCE_STATUS_LABELS[s]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="flex items-center gap-1.5">
+          <CalendarClock className="text-muted-foreground h-4 w-4" />
+          <Input
+            type="date"
+            className="w-36"
+            value={filters.dateFrom ?? ''}
+            onChange={(e) => handleDateFromChange(e.target.value)}
+            placeholder="From"
+          />
+          <span className="text-muted-foreground text-sm">—</span>
+          <Input
+            type="date"
+            className="w-36"
+            value={filters.dateTo ?? ''}
+            onChange={(e) => handleDateToChange(e.target.value)}
+            placeholder="To"
+          />
+        </div>
+
+        {hasFilters && (
+          <Button variant="ghost" size="sm" onClick={() => setFilters({})}>
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {/* Table */}
+      {isLoading ? (
+        <div className="flex justify-center py-16">
+          <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+        </div>
+      ) : events.length === 0 ? (
+        <EmptyState
+          icon={Wrench}
+          title="No maintenance events found"
+          description={
+            hasFilters ? 'Try adjusting your filters.' : 'No maintenance has been scheduled yet.'
+          }
+        />
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Asset</TableHead>
+                <TableHead>Title</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Scheduled</TableHead>
+                <TableHead>Technician</TableHead>
+                <TableHead className="text-right">Cost</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {events.map((event) => (
+                <TableRow key={event.id}>
+                  <TableCell>
+                    <Link
+                      href={`/orgs/${orgSlug}/assets/${event.assetId}`}
+                      className="hover:text-primary font-medium underline-offset-4 hover:underline"
+                    >
+                      {event.assetName}
+                    </Link>
+                    {event.departmentName && (
+                      <p className="text-muted-foreground text-xs">{event.departmentName}</p>
+                    )}
+                  </TableCell>
+                  <TableCell>{event.title}</TableCell>
+                  <TableCell>
+                    <Badge variant="outline" className="text-xs">
+                      {MAINTENANCE_TYPE_LABELS[event.type]}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[event.status]}`}
+                    >
+                      {MAINTENANCE_STATUS_LABELS[event.status]}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-sm">{formatDate(event.scheduledDate)}</TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {event.technicianName ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-right text-sm">
+                    {event.cost != null ? formatCurrency(event.cost) : '—'}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/orgs/[slug]/maintenance/page.tsx
+++ b/src/app/(app)/orgs/[slug]/maintenance/page.tsx
@@ -6,7 +6,6 @@ import { useState } from 'react'
 
 import { EmptyState } from '@/components/shared/EmptyState'
 import { PageHeader } from '@/components/shared/PageHeader'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -41,6 +40,12 @@ const STATUS_COLORS: Record<MaintenanceListItem['status'], string> = {
   scheduled: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   in_progress: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
   completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+}
+
+const TYPE_COLORS: Record<MaintenanceListItem['type'], string> = {
+  preventive: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  corrective: 'bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-400',
+  inspection: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
 }
 
 export default function MaintenancePage() {
@@ -161,9 +166,11 @@ export default function MaintenancePage() {
                   </TableCell>
                   <TableCell>{event.title}</TableCell>
                   <TableCell>
-                    <Badge variant="outline" className="text-xs">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[event.type]}`}
+                    >
                       {MAINTENANCE_TYPE_LABELS[event.type]}
-                    </Badge>
+                    </span>
                   </TableCell>
                   <TableCell>
                     <span

--- a/src/app/(app)/orgs/[slug]/maintenance/page.tsx
+++ b/src/app/(app)/orgs/[slug]/maintenance/page.tsx
@@ -55,22 +55,14 @@ export default function MaintenancePage() {
   const [filters, setFilters] = useState<MaintenanceListFilters>({})
   const { data: events, isLoading } = useMaintenanceList(filters)
 
-  function handleStatusChange(value: string) {
+  function setFilter(key: keyof MaintenanceListFilters, value: string) {
     setFilters((f) => ({
       ...f,
-      status: value === '__all__' ? '' : (value as MaintenanceListFilters['status']),
+      [key]: value && value !== '__all__' ? value : undefined,
     }))
   }
 
-  function handleDateFromChange(value: string) {
-    setFilters((f) => ({ ...f, dateFrom: value || undefined }))
-  }
-
-  function handleDateToChange(value: string) {
-    setFilters((f) => ({ ...f, dateTo: value || undefined }))
-  }
-
-  const hasFilters = !!filters.status || !!filters.dateFrom || !!filters.dateTo
+  const hasFilters = Object.values(filters).some(Boolean)
 
   return (
     <div className="space-y-6">
@@ -83,7 +75,7 @@ export default function MaintenancePage() {
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-2">
-        <Select value={filters.status || '__all__'} onValueChange={handleStatusChange}>
+        <Select value={filters.status || '__all__'} onValueChange={(v) => setFilter('status', v)}>
           <SelectTrigger className="w-36">
             <SelectValue placeholder="All statuses" />
           </SelectTrigger>
@@ -103,7 +95,7 @@ export default function MaintenancePage() {
             type="date"
             className="w-36"
             value={filters.dateFrom ?? ''}
-            onChange={(e) => handleDateFromChange(e.target.value)}
+            onChange={(e) => setFilter('dateFrom', e.target.value)}
             placeholder="From"
           />
           <span className="text-muted-foreground text-sm">—</span>
@@ -111,7 +103,7 @@ export default function MaintenancePage() {
             type="date"
             className="w-36"
             value={filters.dateTo ?? ''}
-            onChange={(e) => handleDateToChange(e.target.value)}
+            onChange={(e) => setFilter('dateTo', e.target.value)}
             placeholder="To"
           />
         </div>

--- a/src/app/(app)/orgs/[slug]/maintenance/page.tsx
+++ b/src/app/(app)/orgs/[slug]/maintenance/page.tsx
@@ -56,10 +56,7 @@ export default function MaintenancePage() {
   const { data: events, isLoading } = useMaintenanceList(filters)
 
   function setFilter(key: keyof MaintenanceListFilters, value: string) {
-    setFilters((f) => ({
-      ...f,
-      [key]: value && value !== '__all__' ? value : undefined,
-    }))
+    setFilters((f) => ({ ...f, [key]: value || undefined }))
   }
 
   const hasFilters = Object.values(filters).some(Boolean)
@@ -75,7 +72,10 @@ export default function MaintenancePage() {
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-2">
-        <Select value={filters.status || '__all__'} onValueChange={(v) => setFilter('status', v)}>
+        <Select
+          value={filters.status || '__all__'}
+          onValueChange={(v) => setFilter('status', v === '__all__' ? '' : v)}
+        >
           <SelectTrigger className="w-36">
             <SelectValue placeholder="All statuses" />
           </SelectTrigger>

--- a/src/app/(app)/orgs/[slug]/maintenance/page.tsx
+++ b/src/app/(app)/orgs/[slug]/maintenance/page.tsx
@@ -31,6 +31,7 @@ import {
 import {
   MAINTENANCE_STATUSES,
   MAINTENANCE_STATUS_LABELS,
+  MAINTENANCE_TYPES,
   MAINTENANCE_TYPE_LABELS,
 } from '@/lib/types/maintenance'
 import { formatCurrency, formatDate } from '@/lib/utils/formatters'
@@ -84,6 +85,23 @@ export default function MaintenancePage() {
             {MAINTENANCE_STATUSES.map((s) => (
               <SelectItem key={s} value={s}>
                 {MAINTENANCE_STATUS_LABELS[s]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.type || '__all__'}
+          onValueChange={(v) => setFilter('type', v === '__all__' ? '' : v)}
+        >
+          <SelectTrigger className="w-36">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All types</SelectItem>
+            {MAINTENANCE_TYPES.map((t) => (
+              <SelectItem key={t} value={t}>
+                {MAINTENANCE_TYPE_LABELS[t]}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/components/assets/MaintenanceTab.tsx
+++ b/src/components/assets/MaintenanceTab.tsx
@@ -19,7 +19,6 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useAssetMaintenanceEvents } from '@/lib/hooks/useMaintenance'
@@ -38,6 +37,12 @@ const STATUS_COLORS: Record<MaintenanceEvent['status'], string> = {
   scheduled: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   in_progress: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
   completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+}
+
+const TYPE_COLORS: Record<MaintenanceEvent['type'], string> = {
+  preventive: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  corrective: 'bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-400',
+  inspection: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
 }
 
 interface MaintenanceTabProps {
@@ -207,9 +212,11 @@ function MaintenanceEventCard({
             {/* Title + badges */}
             <div className="flex flex-wrap items-center gap-2">
               <span className="text-foreground font-medium">{event.title}</span>
-              <Badge variant="outline" className="text-xs">
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[event.type]}`}
+              >
                 {MAINTENANCE_TYPE_LABELS[event.type]}
-              </Badge>
+              </span>
               <span
                 className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[event.status]}`}
               >

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Tag,
   Truck,
   Users,
+  Wrench,
 } from 'lucide-react'
 import Link from 'next/link'
 import { useParams, usePathname } from 'next/navigation'
@@ -34,6 +35,7 @@ function buildNavMain(base: string): NavItem[] {
   return [
     { label: 'Dashboard', href: `${base}/dashboard`, icon: LayoutDashboard },
     { label: 'Assets', href: `${base}/assets`, icon: Package },
+    { label: 'Maintenance', href: `${base}/maintenance`, icon: Wrench },
     { label: 'Reports', href: `${base}/reports`, icon: BarChart3 },
   ]
 }

--- a/src/lib/hooks/useMaintenance.ts
+++ b/src/lib/hooks/useMaintenance.ts
@@ -1,8 +1,9 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 
+import { createPolicy } from '@/lib/permissions'
 import { createClient } from '@/lib/supabase/client'
-import type { MaintenanceEvent } from '@/lib/types/maintenance'
+import type { MaintenanceEvent, MaintenanceStatus } from '@/lib/types/maintenance'
 import { useOrg } from '@/providers/OrgProvider'
 
 function mapEvent(r: Record<string, unknown>): MaintenanceEvent {
@@ -53,6 +54,104 @@ export function useAssetMaintenanceEvents(assetId: string): {
   const refresh = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ['maintenanceEvents', assetId] })
   }, [queryClient, assetId])
+
+  return { data, isLoading, refresh }
+}
+
+// ---------------------------------------------------------------------------
+// useMaintenanceList — org-wide list (global maintenance page)
+// ---------------------------------------------------------------------------
+
+export type MaintenanceListFilters = {
+  status?: MaintenanceStatus | ''
+  dateFrom?: string
+  dateTo?: string
+}
+
+export type MaintenanceListItem = MaintenanceEvent & {
+  assetName: string
+  assetTag: string
+  departmentName: string | null
+}
+
+export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
+  data: MaintenanceListItem[]
+  isLoading: boolean
+  refresh: () => void
+} {
+  const { org, role, departmentIds } = useOrg()
+  const orgId = org?.id ?? ''
+  const queryClient = useQueryClient()
+
+  const constraint = createPolicy({ role: role ?? 'viewer', departmentIds }).queryConstraint()
+
+  const { data = [], isLoading } = useQuery({
+    queryKey: [
+      'maintenanceList',
+      orgId,
+      role,
+      JSON.stringify(departmentIds),
+      filters.status,
+      filters.dateFrom,
+      filters.dateTo,
+    ],
+    enabled: !!orgId,
+    queryFn: async () => {
+      const supabase = createClient()
+
+      // Short-circuit: no department assignments → nothing visible
+      if (constraint.kind === 'none') return []
+
+      // For department-scoped roles, resolve allowed asset IDs first
+      let allowedAssetIds: string[] | null = null
+      if (constraint.kind === 'in') {
+        const { data: assets } = await supabase
+          .from('assets')
+          .select('id')
+          .eq('org_id', orgId)
+          .is('deleted_at', null)
+          .in('department_id', constraint.ids)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ids = (assets ?? []).map((a: any) => a.id as string)
+        if (ids.length === 0) return []
+        allowedAssetIds = ids
+      }
+
+      let query = supabase
+        .from('maintenance_events')
+        .select('*, assets!inner(name, asset_tag, departments(name))')
+        .eq('org_id', orgId)
+        .is('deleted_at', null)
+        .order('scheduled_date', { ascending: false })
+
+      if (allowedAssetIds !== null) query = query.in('asset_id', allowedAssetIds)
+      if (filters.status) query = query.eq('status', filters.status)
+      if (filters.dateFrom) query = query.gte('scheduled_date', filters.dateFrom)
+      if (filters.dateTo) query = query.lte('scheduled_date', filters.dateTo)
+
+      const { data: rows } = await query
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (rows ?? []).map((r: any) => {
+        const asset = r.assets as {
+          name: string
+          asset_tag: string
+          departments: { name: string } | null
+        }
+        return {
+          ...mapEvent(r as unknown as Record<string, unknown>),
+          assetName: asset.name,
+          assetTag: asset.asset_tag,
+          departmentName: asset.departments?.name ?? null,
+        }
+      })
+    },
+    staleTime: 30_000,
+  })
+
+  const refresh = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['maintenanceList'] })
+  }, [queryClient])
 
   return { data, isLoading, refresh }
 }

--- a/src/lib/hooks/useMaintenance.ts
+++ b/src/lib/hooks/useMaintenance.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 
 import { createPolicy } from '@/lib/permissions'
 import { createClient } from '@/lib/supabase/client'
-import type { MaintenanceEvent, MaintenanceStatus } from '@/lib/types/maintenance'
+import type { MaintenanceEvent, MaintenanceStatus, MaintenanceType } from '@/lib/types/maintenance'
 import { useOrg } from '@/providers/OrgProvider'
 
 function mapEvent(r: Record<string, unknown>): MaintenanceEvent {
@@ -64,6 +64,7 @@ export function useAssetMaintenanceEvents(assetId: string): {
 
 export type MaintenanceListFilters = {
   status?: MaintenanceStatus | ''
+  type?: MaintenanceType | ''
   dateFrom?: string
   dateTo?: string
 }
@@ -92,6 +93,7 @@ export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
       role,
       JSON.stringify(departmentIds),
       filters.status,
+      filters.type,
       filters.dateFrom,
       filters.dateTo,
     ],
@@ -125,6 +127,7 @@ export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
 
       if (allowedAssetIds !== null) query = query.in('asset_id', allowedAssetIds)
       if (filters.status) query = query.eq('status', filters.status)
+      if (filters.type) query = query.eq('type', filters.type)
       if (filters.dateFrom) query = query.gte('scheduled_date', filters.dateFrom)
       if (filters.dateTo) query = query.lte('scheduled_date', filters.dateTo)
 

--- a/src/lib/hooks/useMaintenance.ts
+++ b/src/lib/hooks/useMaintenance.ts
@@ -111,8 +111,7 @@ export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
           .eq('org_id', orgId)
           .is('deleted_at', null)
           .in('department_id', constraint.ids)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const ids = (assets ?? []).map((a: any) => a.id as string)
+        const ids = ((assets ?? []) as { id: string }[]).map((a) => a.id)
         if (ids.length === 0) return []
         allowedAssetIds = ids
       }
@@ -131,20 +130,20 @@ export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
 
       const { data: rows } = await query
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (rows ?? []).map((r: any) => {
-        const asset = r.assets as {
+      type MaintenanceRow = Record<string, unknown> & {
+        assets: {
           name: string
           asset_tag: string
           departments: { name: string } | null
         }
-        return {
-          ...mapEvent(r as unknown as Record<string, unknown>),
-          assetName: asset.name,
-          assetTag: asset.asset_tag,
-          departmentName: asset.departments?.name ?? null,
-        }
-      })
+      }
+
+      return ((rows ?? []) as MaintenanceRow[]).map((r) => ({
+        ...mapEvent(r),
+        assetName: r.assets.name,
+        assetTag: r.assets.asset_tag,
+        departmentName: r.assets.departments?.name ?? null,
+      }))
     },
     staleTime: 30_000,
   })


### PR DESCRIPTION
## Summary

- New `/orgs/[slug]/maintenance` route visible to all org members
- Table with columns: Asset (linked to detail page), Title, Type, Status, Scheduled Date, Technician, Cost
- Filterable by status (All / Scheduled / In Progress / Completed) and date range (from/to)
- Admins and Owners see all org-wide events; Editors and Viewers see only events for assets in their assigned departments
- Viewers with no department assignments see an empty state
- "Maintenance" added to the sidebar nav between Assets and Reports with the Wrench icon
- `useMaintenanceList` hook handles department scoping via two-step query (resolve allowed asset IDs first, then filter events)

## Closes

Closes #75

## Test plan

- [ ] Maintenance link appears in sidebar for all roles
- [ ] Page loads and shows events in the table
- [ ] Status filter narrows results correctly
- [ ] Date range filter narrows by scheduled_date
- [ ] Clear button resets all filters
- [ ] Asset name links to `/orgs/[slug]/assets/[id]`
- [ ] As Editor: only events for assets in assigned departments are shown
- [ ] As Viewer with no departments: empty state shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)