### PR TITLE
feat(maintenance): dashboard upcoming maintenance card & checkout warning (#76)

### DIFF
--- a/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
@@ -27,6 +27,7 @@ import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useAsset } from '@/lib/hooks/useAssets'
 import { useAssetHistory } from '@/lib/hooks/useAuditLogs'
+import { useAssetMaintenanceEvents } from '@/lib/hooks/useMaintenance'
 import { createPolicy } from '@/lib/permissions'
 import type { AssetAssignment, AuditLog } from '@/lib/types'
 import { computeMaxForEdit } from '@/lib/utils/availability'
@@ -42,6 +43,7 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
   const { slug } = useParams<{ slug: string }>()
   const { data: asset, isLoading, refresh } = useAsset(id)
   const { data: history, isLoading: historyLoading } = useAssetHistory(id)
+  const { data: maintenanceEvents } = useAssetMaintenanceEvents(id)
   const { org, role, departmentIds } = useOrg()
   const deptLabel = org?.departmentLabel ?? 'Department'
   const router = useRouter()
@@ -372,6 +374,7 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
           open={checkoutOpen}
           onOpenChange={setCheckoutOpen}
           onSuccess={refresh}
+          scheduledEvent={maintenanceEvents.find((e) => e.status === 'scheduled') ?? null}
         />
       )}
 
@@ -558,6 +561,8 @@ const ACTION_LABELS: Record<AuditLog['action'], string> = {
   maintenance_scheduled: 'Maintenance scheduled',
   maintenance_started: 'Maintenance started',
   maintenance_completed: 'Maintenance completed',
+  maintenance_updated: 'Maintenance updated',
+  maintenance_deleted: 'Maintenance deleted',
 }
 
 const ACTION_COLORS: Record<AuditLog['action'], string> = {
@@ -572,6 +577,8 @@ const ACTION_COLORS: Record<AuditLog['action'], string> = {
   maintenance_scheduled: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400',
   maintenance_started: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
   maintenance_completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  maintenance_updated: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  maintenance_deleted: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
 }
 
 function AuditLogRow({ log, isLast }: { log: AuditLog; isLast: boolean }) {

--- a/src/app/(app)/orgs/[slug]/dashboard/page.tsx
+++ b/src/app/(app)/orgs/[slug]/dashboard/page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic'
 
 import { RecentActivity } from '@/components/dashboard/RecentActivity'
 import { StatCard } from '@/components/dashboard/StatCard'
+import { UpcomingMaintenance } from '@/components/dashboard/UpcomingMaintenance'
 import { WarrantyAlerts } from '@/components/dashboard/WarrantyAlerts'
 import { FadeIn } from '@/components/motion/FadeIn'
 import { StaggerChildren, StaggerItem } from '@/components/motion/StaggerChildren'
@@ -50,6 +51,7 @@ export default function DashboardPage() {
   const showCardValue = cfg.showCardValue ?? true
   const showCharts = cfg.showCharts ?? true
   const showWarranty = cfg.showWarranty ?? true
+  const showMaintenanceAlerts = cfg.showMaintenanceAlerts ?? true
   const showActivity = cfg.showActivity ?? true
   const deptLabel = org?.departmentLabel ?? 'Department'
 
@@ -141,11 +143,12 @@ export default function DashboardPage() {
         </FadeIn>
       )}
 
-      {/* Activity + Warranty */}
-      {(showActivity || showWarranty) && (
+      {/* Activity + Warranty + Upcoming Maintenance */}
+      {(showActivity || showWarranty || showMaintenanceAlerts) && (
         <FadeIn delay={0.18} className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           {showActivity && <RecentActivity logs={logs} />}
           {showWarranty && <WarrantyAlerts alerts={stats.warrantyAlerts} />}
+          {showMaintenanceAlerts && <UpcomingMaintenance alerts={stats.upcomingMaintenance} />}
         </FadeIn>
       )}
 

--- a/src/app/(app)/orgs/[slug]/settings/org/page.tsx
+++ b/src/app/(app)/orgs/[slug]/settings/org/page.tsx
@@ -77,6 +77,7 @@ const DASHBOARD_SECTION_TOGGLES: ConfigToggle<DashboardConfig>[] = [
   // description is rendered dynamically (depends on departmentLabel)
   { key: 'showCharts', label: 'Charts', default: true },
   { key: 'showWarranty', label: 'Warranty alerts', default: true },
+  { key: 'showMaintenanceAlerts', label: 'Upcoming maintenance', default: true },
   { key: 'showActivity', label: 'Recent activity', default: true },
 ]
 

--- a/src/components/assets/CheckoutModal.tsx
+++ b/src/components/assets/CheckoutModal.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form'
 
 import { checkoutAsset } from '@/app/actions/assets'
 import { QuickAddDialog } from '@/components/shared/QuickAddDialog'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -37,6 +38,8 @@ import { useDepartmentMutations, useDepartments } from '@/lib/hooks/useDepartmen
 import { useLocationMutations, useLocations } from '@/lib/hooks/useLocations'
 import { CheckoutFormSchema, type CheckoutFormInput } from '@/lib/types'
 import type { TypedAsset } from '@/lib/types'
+import type { MaintenanceEvent } from '@/lib/types/maintenance'
+import { formatDate } from '@/lib/utils/formatters'
 import { useAuth } from '@/providers/AuthProvider'
 import { useOrg } from '@/providers/OrgProvider'
 
@@ -45,9 +48,16 @@ interface CheckoutModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onSuccess?: () => void
+  scheduledEvent?: MaintenanceEvent | null
 }
 
-export function CheckoutModal({ asset, open, onOpenChange, onSuccess }: CheckoutModalProps) {
+export function CheckoutModal({
+  asset,
+  open,
+  onOpenChange,
+  onSuccess,
+  scheduledEvent,
+}: CheckoutModalProps) {
   const { user } = useAuth()
   const { org, membership } = useOrg()
   const orgSlug = membership?.orgSlug ?? ''
@@ -94,6 +104,15 @@ export function CheckoutModal({ asset, open, onOpenChange, onSuccess }: Checkout
             <span className="text-foreground font-medium">{asset.name}</span>
             <span className="ml-2">{asset.ui.checkoutSubtitle}</span>
           </p>
+          {scheduledEvent && (
+            <Alert className="border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-300">
+              <AlertDescription className="text-xs">
+                Maintenance &ldquo;{scheduledEvent.title}&rdquo; is scheduled for{' '}
+                {formatDate(scheduledEvent.scheduledDate)}. Checking out may conflict with this
+                work.
+              </AlertDescription>
+            </Alert>
+          )}
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <FormField

--- a/src/components/dashboard/RecentActivity.tsx
+++ b/src/components/dashboard/RecentActivity.tsx
@@ -30,6 +30,8 @@ const ACTION_CONFIG: Record<
   maintenance_scheduled: { label: 'Maintenance scheduled', icon: Wrench, color: 'text-cyan-500' },
   maintenance_started: { label: 'Maintenance started', icon: Wrench, color: 'text-amber-500' },
   maintenance_completed: { label: 'Maintenance completed', icon: Wrench, color: 'text-green-500' },
+  maintenance_updated: { label: 'Maintenance updated', icon: Wrench, color: 'text-blue-500' },
+  maintenance_deleted: { label: 'Maintenance deleted', icon: Wrench, color: 'text-destructive' },
 }
 
 interface RecentActivityProps {

--- a/src/components/dashboard/UpcomingMaintenance.tsx
+++ b/src/components/dashboard/UpcomingMaintenance.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { CalendarClock, CheckCircle } from 'lucide-react'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import type { UpcomingMaintenanceAlert } from '@/lib/types'
+import { formatDate } from '@/lib/utils/formatters'
+
+interface UpcomingMaintenanceProps {
+  alerts: UpcomingMaintenanceAlert[]
+}
+
+export function UpcomingMaintenance({ alerts }: UpcomingMaintenanceProps) {
+  const { slug } = useParams<{ slug: string }>()
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-semibold">
+          <CalendarClock className="h-4 w-4 text-blue-500" />
+          Upcoming Maintenance
+          {alerts.length > 0 && (
+            <Badge variant="secondary" className="ml-auto text-xs">
+              {alerts.length}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <ScrollArea className="h-64">
+          {alerts.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 px-5 py-8 text-center">
+              <CheckCircle className="h-8 w-8 text-green-500 opacity-60" />
+              <p className="text-muted-foreground text-sm">
+                No maintenance scheduled in the next 30 days.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-border divide-y">
+              {alerts.map((alert) => (
+                <li key={alert.eventId} className="flex items-start gap-3 px-5 py-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-foreground truncate text-xs font-medium">{alert.title}</p>
+                    <p className="text-muted-foreground text-xs">
+                      <Link
+                        href={`/orgs/${slug}/assets/${alert.assetId}`}
+                        className="hover:text-primary hover:underline"
+                      >
+                        {alert.assetName}
+                      </Link>
+                      {alert.departmentName ? ` · ${alert.departmentName}` : ''}
+                    </p>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <Badge
+                      variant={alert.daysUntil <= 7 ? 'destructive' : 'secondary'}
+                      className="text-xs"
+                    >
+                      {alert.daysUntil}d
+                    </Badge>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      {formatDate(alert.scheduledDate)}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/hooks/useDashboardStats.ts
+++ b/src/lib/hooks/useDashboardStats.ts
@@ -5,6 +5,7 @@ import type {
   DashboardStats,
   DepartmentBreakdown,
   StatusBreakdown,
+  UpcomingMaintenanceAlert,
   WarrantyAlert,
 } from '@/lib/types'
 import { useOrg } from '@/providers/OrgProvider'
@@ -15,6 +16,7 @@ const EMPTY: DashboardStats = {
   byStatus: [],
   byDepartment: [],
   warrantyAlerts: [],
+  upcomingMaintenance: [],
   recentActivityCount: 0,
 }
 
@@ -29,7 +31,9 @@ export function useDashboardStats(): { data: DashboardStats; isLoading: boolean 
       const supabase = createClient()
       const thirtyDays = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
 
-      const [aggregates, warrantyRows, activityCount] = await Promise.all([
+      const today = new Date().toISOString().split('T')[0]
+
+      const [aggregates, warrantyRows, upcomingMaintenanceRows, activityCount] = await Promise.all([
         supabase
           .from('assets')
           .select('status, department_id, purchase_cost, departments(name)')
@@ -44,6 +48,18 @@ export function useDashboardStats(): { data: DashboardStats; isLoading: boolean 
           .not('warranty_expiry', 'is', null)
           .lte('warranty_expiry', thirtyDays)
           .order('warranty_expiry'),
+
+        supabase
+          .from('maintenance_events')
+          .select(
+            'id, asset_id, title, scheduled_date, assets!inner(asset_tag, name, departments(name))'
+          )
+          .eq('org_id', orgId)
+          .eq('status', 'scheduled')
+          .is('deleted_at', null)
+          .gte('scheduled_date', today)
+          .lte('scheduled_date', thirtyDays)
+          .order('scheduled_date'),
 
         supabase
           .from('audit_logs')
@@ -88,14 +104,12 @@ export function useDashboardStats(): { data: DashboardStats; isLoading: boolean 
         }))
         .sort((a, b) => b.count - a.count)
 
-      const today = new Date()
+      const now = new Date()
       const warrantyAlerts: WarrantyAlert[] = (
         (warrantyRows.data ?? []) as Record<string, unknown>[]
       ).map((r) => {
         const expiry = new Date(r.warranty_expiry as string)
-        const daysRemaining = Math.ceil(
-          (expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
-        )
+        const daysRemaining = Math.ceil((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
         return {
           assetId: r.id as string,
           assetTag: r.asset_tag as string,
@@ -106,12 +120,33 @@ export function useDashboardStats(): { data: DashboardStats; isLoading: boolean 
         }
       })
 
+      type MaintenanceRow = Record<string, unknown> & {
+        assets: { asset_tag: string; name: string; departments: { name: string } | null }
+      }
+      const upcomingMaintenance: UpcomingMaintenanceAlert[] = (
+        (upcomingMaintenanceRows.data ?? []) as MaintenanceRow[]
+      ).map((r) => {
+        const scheduled = new Date(r.scheduled_date as string)
+        const daysUntil = Math.ceil((scheduled.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+        return {
+          eventId: r.id as string,
+          assetId: r.asset_id as string,
+          assetTag: r.assets.asset_tag,
+          assetName: r.assets.name,
+          departmentName: r.assets.departments?.name ?? null,
+          title: r.title as string,
+          scheduledDate: r.scheduled_date as string,
+          daysUntil,
+        }
+      })
+
       return {
         totalAssets,
         totalValue,
         byStatus,
         byDepartment,
         warrantyAlerts,
+        upcomingMaintenance,
         recentActivityCount: activityCount.count ?? 0,
       }
     },

--- a/src/lib/types/audit.ts
+++ b/src/lib/types/audit.ts
@@ -16,6 +16,8 @@ export const AuditActionSchema = z.enum([
   'maintenance_scheduled',
   'maintenance_started',
   'maintenance_completed',
+  'maintenance_updated',
+  'maintenance_deleted',
 ])
 
 export type AuditAction = z.infer<typeof AuditActionSchema>

--- a/src/lib/types/dashboard.ts
+++ b/src/lib/types/dashboard.ts
@@ -33,12 +33,26 @@ export const WarrantyAlertSchema = z.object({
 
 export type WarrantyAlert = z.infer<typeof WarrantyAlertSchema>
 
+export const UpcomingMaintenanceAlertSchema = z.object({
+  eventId: z.string().uuid(),
+  assetId: z.string().uuid(),
+  assetTag: z.string(),
+  assetName: z.string(),
+  departmentName: z.string().nullable(),
+  title: z.string(),
+  scheduledDate: z.string(), // ISO date YYYY-MM-DD
+  daysUntil: z.number().int(),
+})
+
+export type UpcomingMaintenanceAlert = z.infer<typeof UpcomingMaintenanceAlertSchema>
+
 export const DashboardStatsSchema = z.object({
   totalAssets: z.number().int().min(0),
   totalValue: z.number().nonnegative(),
   byStatus: z.array(StatusBreakdownSchema),
   byDepartment: z.array(DepartmentBreakdownSchema),
   warrantyAlerts: z.array(WarrantyAlertSchema),
+  upcomingMaintenance: z.array(UpcomingMaintenanceAlertSchema),
   recentActivityCount: z.number().int().min(0),
 })
 

--- a/src/lib/types/org.ts
+++ b/src/lib/types/org.ts
@@ -14,6 +14,7 @@ export const DashboardConfigSchema = z.object({
   // Sections
   showCharts: z.boolean().optional(),
   showWarranty: z.boolean().optional(),
+  showMaintenanceAlerts: z.boolean().optional(),
   showActivity: z.boolean().optional(),
 })
 


### PR DESCRIPTION
## Summary

- **Upcoming Maintenance card** on the dashboard: queries `maintenance_events` with `status = 'scheduled'` and `scheduled_date` within the next 30 days, displays as a scrollable card with days-until badge (red ≤7d, grey otherwise) — mirrors `WarrantyAlerts`
- **Checkout warning**: `CheckoutModal` now accepts an optional `scheduledEvent` prop; if the asset has a scheduled maintenance event, an amber alert is shown above the form so the user knows before checking out
- **Settings toggle**: `showMaintenanceAlerts` added to `DashboardConfigSchema` and `DASHBOARD_SECTION_TOGGLES` — defaults on
- **Audit action types**: `maintenance_updated` and `maintenance_deleted` added to `AuditActionSchema` and all action label/color maps (asset detail page, dashboard recent activity)

## Test plan

- [ ] Dashboard shows "Upcoming Maintenance" card with scheduled events in the next 30 days
- [ ] Card shows empty state when no upcoming events exist
- [ ] Days badge turns red for events ≤7 days away
- [ ] Asset name in card links to the asset detail page
- [ ] Checking out an asset with a scheduled event shows the amber warning in the modal
- [ ] Checking out an asset with no scheduled events shows no warning
- [ ] Settings toggle hides/shows the card as expected
- [ ] History tab on asset detail renders `maintenance_updated` and `maintenance_deleted` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)