### PR TITLE
fix: make updateUserDepartmentsAction atomic via DB function (#34)

### DIFF
--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -70,27 +70,15 @@ export async function updateUserDepartmentsAction(
   const denied = ctx.requireRole('admin')
   if (denied) return denied
 
-  // Replace all department memberships for this user within the active org
-  const { error: deleteError } = await ctx.admin
-    .from('user_departments')
-    .delete()
-    .eq('user_id', userId)
-    .eq('org_id', ctx.orgId)
+  // Replace all department memberships atomically via a DB function —
+  // delete and insert run in a single transaction so partial state is impossible.
+  const { error } = await ctx.admin.rpc('replace_user_departments', {
+    p_user_id: userId,
+    p_org_id: ctx.orgId,
+    p_department_ids: departmentIds,
+  })
 
-  if (deleteError) return { error: deleteError.message }
-
-  if (departmentIds.length > 0) {
-    const { error: insertError } = await ctx.admin.from('user_departments').insert(
-      departmentIds.map((department_id) => ({
-        user_id: userId,
-        department_id,
-        org_id: ctx.orgId,
-      }))
-    )
-    if (insertError) return { error: insertError.message }
-  }
-
-  return { error: null }
+  return { error: error?.message ?? null }
 }
 
 export async function revokeInviteAction(

--- a/supabase/migrations/012_replace_user_departments_fn.sql
+++ b/supabase/migrations/012_replace_user_departments_fn.sql
@@ -1,0 +1,28 @@
+-- Atomically replace all department memberships for a user within an org.
+-- Called via RPC from updateUserDepartmentsAction to guarantee that the
+-- delete and insert succeed or fail together — no partial state possible.
+
+create or replace function public.replace_user_departments(
+  p_user_id       uuid,
+  p_org_id        uuid,
+  p_department_ids uuid[]
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  delete from public.user_departments
+  where user_id = p_user_id
+    and org_id  = p_org_id;
+
+  if array_length(p_department_ids, 1) > 0 then
+    insert into public.user_departments (user_id, org_id, department_id)
+    select p_user_id, p_org_id, unnest(p_department_ids);
+  end if;
+end;
+$$;
+
+revoke all on function public.replace_user_departments(uuid, uuid, uuid[]) from public, anon, authenticated;
+grant execute on function public.replace_user_departments(uuid, uuid, uuid[]) to service_role;


### PR DESCRIPTION
Closes #34

## Summary

- Adds `replace_user_departments(p_user_id, p_org_id, p_department_ids)` — a `security definer` Postgres function that wraps the delete + insert in a single transaction
- `updateUserDepartmentsAction` now calls this via a single `rpc()` instead of two separate queries — partial failure (delete succeeds, insert fails) is no longer possible
- Function is only executable by `service_role`; `public`, `anon`, and `authenticated` are explicitly revoked

## Test plan

- [ ] Assigning departments to a user saves correctly
- [ ] Removing all departments from a user saves correctly
- [ ] Migration applies cleanly to staging and prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)