### PR TITLE
fix(next): add error.tsx and global-error.tsx error boundaries

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { AlertTriangleIcon } from 'lucide-react'
+import { useEffect } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="bg-background flex min-h-screen flex-col items-center justify-center gap-4 text-center">
+      <AlertTriangleIcon className="text-destructive size-10" />
+      <h1 className="text-foreground text-xl font-semibold">Something went wrong</h1>
+      <p className="text-muted-foreground max-w-sm text-sm">
+        An unexpected error occurred. You can try again or return to the dashboard.
+      </p>
+      {error.digest && (
+        <p className="text-muted-foreground font-mono text-xs">Error ID: {error.digest}</p>
+      )}
+      <Button onClick={reset} size="sm">
+        Try again
+      </Button>
+    </div>
+  )
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          display: 'flex',
+          minHeight: '100vh',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '1rem',
+          textAlign: 'center',
+          fontFamily: 'sans-serif',
+          background: '#f5f0eb',
+          color: '#1a1a2e',
+          margin: 0,
+        }}
+      >
+        <h1 style={{ fontSize: '1.25rem', fontWeight: 600 }}>Something went wrong</h1>
+        <p style={{ fontSize: '0.875rem', color: '#6b7280', maxWidth: '24rem' }}>
+          A critical error occurred. Please reload the page.
+        </p>
+        {error.digest && (
+          <p style={{ fontSize: '0.75rem', fontFamily: 'monospace', color: '#9ca3af' }}>
+            Error ID: {error.digest}
+          </p>
+        )}
+        <button
+          onClick={reset}
+          style={{
+            padding: '0.5rem 1rem',
+            borderRadius: '0.5rem',
+            background: '#5c4ee5',
+            color: '#fff',
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+          }}
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary

Full next-best-practices audit was run across the codebase. All rules passed except one: missing error boundaries.

**Rules audited:**
- ✅ Async params/searchParams (typed as `Promise<...>` and awaited everywhere)
- ✅ Async cookies()/headers() (all awaited)
- ✅ No async client components
- ✅ No non-serializable props crossing RSC boundaries
- ✅ No `redirect()` calls inside try-catch blocks
- ✅ `next/font` used correctly (`Plus_Jakarta_Sans` with CSS variable, `display: swap`)
- ✅ No native `<img>` tags — `next/image` used throughout
- ✅ All `useSearchParams()` calls wrapped in Suspense
- ✅ Metadata exported from root layout with title template
- ✅ Recharts loaded with `dynamic(..., { ssr: false })`
- ❌ **No `error.tsx` or `global-error.tsx`** — fixed in this PR

## What was added

**`src/app/error.tsx`** — catches unhandled errors in any route segment. Shows a user-friendly screen with a "Try again" button and the error digest (for support traceability). Logs the error to console for observability.

**`src/app/global-error.tsx`** — catches errors thrown by the root layout itself. Required to include its own `<html>` and `<body>` tags per Next.js spec. Uses inline styles since Tailwind and fonts are unavailable at this boundary level.

## Test plan

- [ ] Triggering a runtime error in a page renders the error UI with a retry button
- [ ] Error digest is shown when present
- [ ] Clicking "Try again" calls `reset()` and attempts to re-render
- [ ] 278 unit tests pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)