### PR TITLE
fix: Emil design-eng polish + a11y dialog warnings

### DIFF
--- a/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { ArrowLeft, LogIn, LogOut, Loader2, Pencil, Plus, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { notFound, useParams, useRouter } from 'next/navigation'
-import { use, useState } from 'react'
+import { use, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { deleteAsset, restockAsset, returnAsset, returnBulkAssignment } from '@/app/actions/assets'
@@ -50,6 +50,10 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
   const [checkoutOpen, setCheckoutOpen] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [activeTab, setActiveTab] = useState('details')
+
+  useEffect(() => {
+    document.querySelector<HTMLElement>('[data-main-scroll]')?.scrollTo({ top: 0 })
+  }, [activeTab])
   const [restockOpen, setRestockOpen] = useState(false)
   const [returnAssignment, setReturnAssignment] = useState<AssetAssignment | null>(null)
   const [editAssignment, setEditAssignment] = useState<AssetAssignment | null>(null)
@@ -473,7 +477,7 @@ function RestockModal({
   const [qty, setQty] = useState(1)
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-xs">
+      <DialogContent className="sm:max-w-xs" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Restock</DialogTitle>
         </DialogHeader>
@@ -513,7 +517,7 @@ function BulkReturnModal({
   const [qty, setQty] = useState(assignment.quantity)
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-xs">
+      <DialogContent className="sm:max-w-xs" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Return items</DialogTitle>
         </DialogHeader>

--- a/src/app/(app)/orgs/[slug]/users/page.tsx
+++ b/src/app/(app)/orgs/[slug]/users/page.tsx
@@ -354,7 +354,7 @@ export default function UsersPage() {
 
       {/* Invite modal */}
       <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Invite a team member</DialogTitle>
           </DialogHeader>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 
 @custom-variant dark (&:is(.dark *));
+@custom-variant can-hover (@media (hover: hover) and (pointer: fine));
 
 :root {
   --background: oklch(0.9232 0.0026 48.7171);

--- a/src/components/assets/AssetCard.tsx
+++ b/src/components/assets/AssetCard.tsx
@@ -36,7 +36,7 @@ export function AssetCard({ asset }: AssetCardProps) {
 
   return (
     <>
-      <Card className="group shadow-sm transition-shadow hover:shadow-md">
+      <Card className="group can-hover:hover:shadow-md shadow-sm transition-shadow">
         <CardContent className="p-4">
           <div className="flex items-start justify-between gap-2">
             <Link href={`/orgs/${orgSlug}/assets/${asset.id}`} className="min-w-0 flex-1">
@@ -49,7 +49,7 @@ export function AssetCard({ asset }: AssetCardProps) {
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100"
+                    className="can-hover:opacity-0 can-hover:group-hover:opacity-100 h-7 w-7 transition-opacity"
                     aria-label={`More options for ${asset.name}`}
                   >
                     <MoreHorizontal className="h-4 w-4" />

--- a/src/components/assets/CheckoutModal.tsx
+++ b/src/components/assets/CheckoutModal.tsx
@@ -96,7 +96,7 @@ export function CheckoutModal({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Check out {asset.ui.checkoutLabel}</DialogTitle>
           </DialogHeader>

--- a/src/components/assets/CompleteMaintenanceModal.tsx
+++ b/src/components/assets/CompleteMaintenanceModal.tsx
@@ -79,7 +79,7 @@ export function CompleteMaintenanceModal({
         onOpenChange(o)
       }}
     >
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Complete maintenance</DialogTitle>
         </DialogHeader>

--- a/src/components/assets/EditAssignmentModal.tsx
+++ b/src/components/assets/EditAssignmentModal.tsx
@@ -109,7 +109,7 @@ export function EditAssignmentModal({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Edit checkout</DialogTitle>
           </DialogHeader>

--- a/src/components/assets/EditMaintenanceModal.tsx
+++ b/src/components/assets/EditMaintenanceModal.tsx
@@ -104,7 +104,7 @@ export function EditMaintenanceModal({
         onOpenChange(o)
       }}
     >
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Edit maintenance event</DialogTitle>
         </DialogHeader>

--- a/src/components/assets/ScheduleMaintenanceModal.tsx
+++ b/src/components/assets/ScheduleMaintenanceModal.tsx
@@ -95,7 +95,7 @@ export function ScheduleMaintenanceModal({
         onOpenChange(o)
       }}
     >
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>
             {isRetroactive ? 'Log past maintenance' : 'Schedule maintenance'}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -21,7 +21,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="bg-background flex h-screen overflow-hidden">
+    <div className="bg-background flex h-dvh overflow-hidden">
       {/* Desktop sidebar */}
       <aside className="hidden w-60 shrink-0 lg:block">
         <Sidebar />
@@ -41,7 +41,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <Topbar onMenuClick={() => setMobileOpen(true)} />
         <main className="min-h-0 flex-1 overflow-hidden">
-          <div className="h-full overflow-y-auto p-6">{children}</div>
+          <div data-main-scroll className="h-full overflow-y-auto p-6">
+            {children}
+          </div>
         </main>
       </div>
     </div>

--- a/src/components/motion/PageTransition.tsx
+++ b/src/components/motion/PageTransition.tsx
@@ -1,20 +1,20 @@
 'use client'
 
-import { motion } from 'framer-motion'
 import { usePathname } from 'next/navigation'
-
-const easeOut: [number, number, number, number] = [0.23, 1, 0.32, 1]
+import { useEffect } from 'react'
 
 export function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+
+  // Reset the custom scroll container on every navigation so users
+  // always land at the top of the new page.
+  useEffect(() => {
+    document.querySelector<HTMLElement>('[data-main-scroll]')?.scrollTo({ top: 0 })
+  }, [pathname])
+
   return (
-    <motion.div
-      key={pathname}
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.18, ease: easeOut }}
-    >
+    <div key={pathname} className="animate-in fade-in-0 duration-200">
       {children}
-    </motion.div>
+    </div>
   )
 }

--- a/src/components/shared/QuickAddDialog.tsx
+++ b/src/components/shared/QuickAddDialog.tsx
@@ -36,7 +36,7 @@ export function QuickAddDialog({ open, onOpenChange, title, onAdd }: QuickAddDia
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-sm">
+      <DialogContent className="sm:max-w-sm" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -43,6 +43,7 @@ function SheetContent({
   children,
   side = 'right',
   showCloseButton = true,
+  'aria-describedby': ariaDescribedBy,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left'
@@ -53,6 +54,7 @@ function SheetContent({
       <SheetOverlay />
       <SheetPrimitive.Content
         data-slot="sheet-content"
+        aria-describedby={ariaDescribedBy}
         className={cn(
           'bg-background data-[state=closed]:animate-out data-[state=open]:animate-in fixed z-50 flex flex-col gap-4 shadow-lg transition data-[state=closed]:duration-200 data-[state=closed]:ease-in data-[state=open]:duration-300 data-[state=open]:ease-[var(--ease-drawer)]',
           side === 'right' &&

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -5,21 +5,67 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
+// ---------------------------------------------------------------------------
+// Instant-on-subsequent context
+// Tracks whether any tooltip was recently open. When true, the next tooltip
+// skips its entry animation (duration-0) matching Emil Kowalski's pattern:
+// first hover has a delay + animation; subsequent hovers are instant.
+// ---------------------------------------------------------------------------
+
+type InstantCtx = {
+  isInstant: boolean
+  signal: (open: boolean) => void
+}
+
+const InstantContext = React.createContext<InstantCtx>({
+  isInstant: false,
+  signal: () => {},
+})
+
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = 400,
+  skipDelayDuration = 500,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  const [isInstant, setIsInstant] = React.useState(false)
+  const timer = React.useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  const signal = React.useCallback(
+    (open: boolean) => {
+      if (open) {
+        clearTimeout(timer.current)
+        setIsInstant(true)
+      } else {
+        timer.current = setTimeout(() => setIsInstant(false), skipDelayDuration)
+      }
+    },
+    [skipDelayDuration]
+  )
+
   return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delayDuration={delayDuration}
-      {...props}
-    />
+    <InstantContext.Provider value={{ isInstant, signal }}>
+      <TooltipPrimitive.Provider
+        data-slot="tooltip-provider"
+        delayDuration={delayDuration}
+        skipDelayDuration={skipDelayDuration}
+        {...props}
+      />
+    </InstantContext.Provider>
   )
 }
 
-function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+function Tooltip({ onOpenChange, ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  const { signal } = React.useContext(InstantContext)
+
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      signal(open)
+      onOpenChange?.(open)
+    },
+    [signal, onOpenChange]
+  )
+
+  return <TooltipPrimitive.Root data-slot="tooltip" onOpenChange={handleOpenChange} {...props} />
 }
 
 function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
@@ -32,6 +78,8 @@ function TooltipContent({
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  const { isInstant } = React.useContext(InstantContext)
+
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -39,6 +87,7 @@ function TooltipContent({
         sideOffset={sideOffset}
         className={cn(
           'animate-in bg-foreground text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          isInstant && 'duration-0',
           className
         )}
         {...props}

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -4,6 +4,7 @@ import { MotionConfig } from 'framer-motion'
 import { ThemeProvider } from 'next-themes'
 
 import { Toaster } from '@/components/ui/sonner'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 import { AuthProvider } from './AuthProvider'
 import { QueryProvider } from './QueryProvider'
@@ -12,12 +13,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <MotionConfig reducedMotion="user">
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-        <QueryProvider>
-          <AuthProvider>
-            {children}
-            <Toaster richColors position="top-right" />
-          </AuthProvider>
-        </QueryProvider>
+        <TooltipProvider>
+          <QueryProvider>
+            <AuthProvider>
+              {children}
+              <Toaster richColors position="top-right" />
+            </AuthProvider>
+          </QueryProvider>
+        </TooltipProvider>
       </ThemeProvider>
     </MotionConfig>
   )


### PR DESCRIPTION
## Summary

- **Hover media query guard** — add `@custom-variant can-hover` in globals.css; guard `AssetCard` hover effects so touch devices always see the action button instead of it being hidden behind `opacity-0`
- **Tooltip instant-on-subsequent** — rewrite `tooltip.tsx` with `InstantContext` tracking open state across tooltips (400ms delay on first, 0ms thereafter); wire `TooltipProvider` into global `Providers`
- **PageTransition** — replace Framer Motion `motion.div` with plain CSS `animate-in` to avoid `will-change: opacity` creating a `position: fixed` containing block; add scroll reset on navigation
- **AppShell** — `h-screen` → `h-dvh`; add `data-main-scroll` attribute for manual scroll reset
- **a11y** — suppress `Missing Description` warnings on all `DialogContent` / `SheetContent` usages that intentionally have no description (`aria-describedby={undefined}`)

## Test plan
- [ ] Hover over asset cards on desktop — action button hidden until hover
- [ ] On touch device / touch emulation — action button always visible
- [ ] Hover multiple tooltips rapidly — first has delay, subsequent open instantly
- [ ] Navigate between pages — scroll resets to top
- [ ] Open Settings — unsaved-changes bar stays fixed to viewport bottom
- [ ] No `Missing Description` warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)