### PR TITLE
feat: skeletons over spinners + asset detail mobile fixes

### DIFF
--- a/src/app/(app)/orgs/[slug]/assets/[id]/edit/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/[id]/edit/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { Loader2 } from 'lucide-react'
 import { notFound, useRouter } from 'next/navigation'
 import { useParams } from 'next/navigation'
 import { use } from 'react'
 
 import { AssetForm } from '@/components/assets/AssetForm'
 import { PageHeader } from '@/components/shared/PageHeader'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useAsset } from '@/lib/hooks/useAssets'
 import { createPolicy } from '@/lib/permissions'
 import { useOrg } from '@/providers/OrgProvider'
@@ -29,8 +29,19 @@ export default function EditAssetPage({ params }: EditAssetPageProps) {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center py-16">
-        <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+      <div className="mx-auto max-w-2xl space-y-6">
+        <div>
+          <Skeleton className="h-7 w-24" />
+          <Skeleton className="mt-1 h-4 w-40" />
+        </div>
+        <div className="space-y-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="space-y-1.5">
+              <Skeleton className="h-3.5 w-20" />
+              <Skeleton className="h-10 w-full rounded-md" />
+            </div>
+          ))}
+        </div>
       </div>
     )
   }

--- a/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowLeft, LogIn, LogOut, Loader2, Pencil, Plus, Trash2 } from 'lucide-react'
+import { ArrowLeft, LogIn, LogOut, Pencil, Plus, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { notFound, useParams, useRouter } from 'next/navigation'
 import { use, useEffect, useState } from 'react'
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useAsset } from '@/lib/hooks/useAssets'
 import { useAssetHistory } from '@/lib/hooks/useAuditLogs'
@@ -60,8 +61,28 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
 
   if (isLoading)
     return (
-      <div className="flex justify-center py-16">
-        <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-20 rounded-md" />
+          <div className="ml-auto flex gap-2">
+            <Skeleton className="h-8 w-8 rounded-md" />
+            <Skeleton className="h-8 w-8 rounded-md" />
+          </div>
+        </div>
+        <div>
+          <Skeleton className="h-8 w-64" />
+          <div className="mt-2 flex gap-2">
+            <Skeleton className="h-5 w-24 rounded-full" />
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </div>
+        </div>
+        <div>
+          <Skeleton className="h-9 w-80 rounded-lg" />
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <Skeleton className="h-40 rounded-xl" />
+            <Skeleton className="h-40 rounded-xl" />
+          </div>
+        </div>
       </div>
     )
   if (!asset) return notFound()
@@ -97,28 +118,28 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
           <div className="ml-auto flex items-center gap-2">
             {canEditAssets && canCheckOut && (
               <Button variant="outline" size="sm" onClick={() => setCheckoutOpen(true)}>
-                <LogOut className="mr-1.5 h-4 w-4" />
-                Check out
+                <LogOut className="h-4 w-4 sm:mr-1.5" />
+                <span className="hidden sm:inline">Check out</span>
               </Button>
             )}
             {canEditAssets && asset.ui.secondaryAction === 'return' && (
               <Button variant="outline" size="sm" onClick={handleReturn}>
-                <LogIn className="mr-1.5 h-4 w-4" />
-                Return
+                <LogIn className="h-4 w-4 sm:mr-1.5" />
+                <span className="hidden sm:inline">Return</span>
               </Button>
             )}
             {canEditAssets && asset.ui.secondaryAction === 'restock' && (
               <Button variant="outline" size="sm" onClick={() => setRestockOpen(true)}>
-                <Plus className="mr-1.5 h-4 w-4" />
-                Restock
+                <Plus className="h-4 w-4 sm:mr-1.5" />
+                <span className="hidden sm:inline">Restock</span>
               </Button>
             )}
             {canEditAssets && (
               <>
                 <Button variant="outline" size="sm" asChild>
                   <Link href={`/orgs/${slug}/assets/${asset.id}/edit`}>
-                    <Pencil className="mr-1.5 h-4 w-4" />
-                    Edit
+                    <Pencil className="h-4 w-4 sm:mr-1.5" />
+                    <span className="hidden sm:inline">Edit</span>
                   </Link>
                 </Button>
                 <Button
@@ -127,8 +148,8 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
                   className="text-destructive hover:text-destructive"
                   onClick={() => setConfirmDelete(true)}
                 >
-                  <Trash2 className="mr-1.5 h-4 w-4" />
-                  Delete
+                  <Trash2 className="h-4 w-4 sm:mr-1.5" />
+                  <span className="hidden sm:inline">Delete</span>
                 </Button>
               </>
             )}
@@ -156,12 +177,14 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
         </div>
 
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList>
-            <TabsTrigger value="details">Details</TabsTrigger>
-            <TabsTrigger value="assignment">{asset.ui.assignmentTabLabel}</TabsTrigger>
-            <TabsTrigger value="maintenance">Maintenance</TabsTrigger>
-            <TabsTrigger value="history">History</TabsTrigger>
-          </TabsList>
+          <div className="overflow-x-auto">
+            <TabsList>
+              <TabsTrigger value="details">Details</TabsTrigger>
+              <TabsTrigger value="assignment">{asset.ui.assignmentTabLabel}</TabsTrigger>
+              <TabsTrigger value="maintenance">Maintenance</TabsTrigger>
+              <TabsTrigger value="history">History</TabsTrigger>
+            </TabsList>
+          </div>
 
           {/* Details tab */}
           <TabsContent value="details" className="mt-4">
@@ -354,8 +377,14 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
           {/* History tab */}
           <TabsContent value="history" className="mt-4">
             {historyLoading ? (
-              <div className="flex justify-center py-12">
-                <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+              <div className="space-y-0 rounded-md border">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-3 border-b px-4 py-3 last:border-0">
+                    <Skeleton className="h-3.5 w-24" />
+                    <Skeleton className="h-3.5 flex-1" />
+                    <Skeleton className="h-3.5 w-20" />
+                  </div>
+                ))}
               </div>
             ) : history.length === 0 ? (
               <div className="text-muted-foreground rounded-md border py-12 text-center text-sm">

--- a/src/app/(app)/orgs/[slug]/assets/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { LayoutGrid, List, Loader2, Plus } from 'lucide-react'
+import { LayoutGrid, List, Plus } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 
@@ -12,6 +12,7 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { PageHeader } from '@/components/shared/PageHeader'
 import { PaginationBar } from '@/components/shared/PaginationBar'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { type AssetFilters, useAssets } from '@/lib/hooks/useAssets'
 import { createPolicy } from '@/lib/permissions'
 import { useOrg } from '@/providers/OrgProvider'
@@ -78,8 +79,16 @@ export default function AssetsPage() {
       </div>
 
       {isLoading ? (
-        <div className="flex justify-center py-16">
-          <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+        <div className="rounded-md border">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 border-b px-4 py-3 last:border-0">
+              <Skeleton className="h-3.5 w-20" />
+              <Skeleton className="h-3.5 flex-1" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-3.5 w-24" />
+              <Skeleton className="h-3.5 w-16" />
+            </div>
+          ))}
         </div>
       ) : assets.length === 0 ? (
         <EmptyState

--- a/src/app/(app)/orgs/[slug]/categories/page.tsx
+++ b/src/app/(app)/orgs/[slug]/categories/page.tsx
@@ -10,7 +10,6 @@ import { countAssetsInCategory } from '@/app/actions/categories'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { PageHeader } from '@/components/shared/PageHeader'
-import { PageLoader } from '@/components/shared/PageLoader'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
@@ -23,6 +22,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Textarea } from '@/components/ui/textarea'
 import { useCategoryMutations, useCategories } from '@/lib/hooks/useCategories'
 import { CategoryFormSchema, type Category, type CategoryFormInput } from '@/lib/types'
@@ -45,7 +45,22 @@ export default function CategoriesPage() {
     defaultValues: { name: '', description: '', icon: '' },
   })
 
-  if (isLoading) return <PageLoader />
+  if (isLoading)
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Categories" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="shadow-sm">
+              <CardContent className="p-4">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="mt-2 h-3 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
 
   function openCreate() {
     setEditing(null)

--- a/src/app/(app)/orgs/[slug]/dashboard/page.tsx
+++ b/src/app/(app)/orgs/[slug]/dashboard/page.tsx
@@ -9,7 +9,6 @@ import { UpcomingMaintenance } from '@/components/dashboard/UpcomingMaintenance'
 import { WarrantyAlerts } from '@/components/dashboard/WarrantyAlerts'
 import { FadeIn } from '@/components/motion/FadeIn'
 import { StaggerChildren, StaggerItem } from '@/components/motion/StaggerChildren'
-import { PageLoader } from '@/components/shared/PageLoader'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useRecentActivity } from '@/lib/hooks/useAuditLogs'
 import { useDashboardStats } from '@/lib/hooks/useDashboardStats'
@@ -41,7 +40,24 @@ export default function DashboardPage() {
   const { data: stats, isLoading } = useDashboardStats()
   const { data: logs } = useRecentActivity(8)
 
-  if (isLoading) return <PageLoader />
+  if (isLoading)
+    return (
+      <div className="space-y-6">
+        <div>
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="mt-1.5 h-4 w-72" />
+        </div>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-[repeat(auto-fit,minmax(160px,1fr))]">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 rounded-xl" />
+          ))}
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Skeleton className="h-[288px] rounded-xl" />
+          <Skeleton className="h-[288px] rounded-xl" />
+        </div>
+      </div>
+    )
 
   const cfg = org?.dashboardConfig ?? {}
   const showCardTotal = cfg.showCardTotal ?? true

--- a/src/app/(app)/orgs/[slug]/departments/page.tsx
+++ b/src/app/(app)/orgs/[slug]/departments/page.tsx
@@ -10,7 +10,6 @@ import { countAssetsInDepartment } from '@/app/actions/departments'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { PageHeader } from '@/components/shared/PageHeader'
-import { PageLoader } from '@/components/shared/PageLoader'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
@@ -23,6 +22,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Textarea } from '@/components/ui/textarea'
 import { useDepartmentMutations, useDepartments } from '@/lib/hooks/useDepartments'
 import { DepartmentFormSchema, type Department, type DepartmentFormInput } from '@/lib/types'
@@ -48,7 +48,22 @@ export default function DepartmentsPage() {
     defaultValues: { name: '', description: '' },
   })
 
-  if (isLoading) return <PageLoader />
+  if (isLoading)
+    return (
+      <div className="space-y-6">
+        <PageHeader title={`${deptLabel}s`} />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="shadow-sm">
+              <CardContent className="p-4">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="mt-2 h-3 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
 
   function openCreate() {
     setEditing(null)

--- a/src/app/(app)/orgs/[slug]/locations/page.tsx
+++ b/src/app/(app)/orgs/[slug]/locations/page.tsx
@@ -8,7 +8,6 @@ import { useForm } from 'react-hook-form'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { PageHeader } from '@/components/shared/PageHeader'
-import { PageLoader } from '@/components/shared/PageLoader'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
@@ -21,6 +20,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Textarea } from '@/components/ui/textarea'
 import { useLocationMutations, useLocations } from '@/lib/hooks/useLocations'
 import { LocationFormSchema, type Location, type LocationFormInput } from '@/lib/types'
@@ -42,7 +42,22 @@ export default function LocationsPage() {
     defaultValues: { name: '', description: '' },
   })
 
-  if (isLoading) return <PageLoader />
+  if (isLoading)
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Locations" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="shadow-sm">
+              <CardContent className="p-4">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="mt-2 h-3 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
 
   function openCreate() {
     setEditing(null)

--- a/src/app/(app)/orgs/[slug]/maintenance/page.tsx
+++ b/src/app/(app)/orgs/[slug]/maintenance/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CalendarClock, Loader2, Wrench } from 'lucide-react'
+import { CalendarClock, Wrench } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 
@@ -15,6 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
   TableBody,
@@ -135,8 +136,17 @@ export default function MaintenancePage() {
 
       {/* Table */}
       {isLoading ? (
-        <div className="flex justify-center py-16">
-          <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+        <div className="rounded-md border">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 border-b px-4 py-3 last:border-0">
+              <Skeleton className="h-3.5 w-28" />
+              <Skeleton className="h-3.5 w-40" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="h-3.5 w-24" />
+              <Skeleton className="h-3.5 w-20" />
+            </div>
+          ))}
         </div>
       ) : events.length === 0 ? (
         <EmptyState

--- a/src/app/(app)/orgs/[slug]/reports/page.tsx
+++ b/src/app/(app)/orgs/[slug]/reports/page.tsx
@@ -6,7 +6,6 @@ import { toast } from 'sonner'
 
 import { AssetStatusBadge } from '@/components/assets/AssetStatusBadge'
 import { PageHeader } from '@/components/shared/PageHeader'
-import { PageLoader } from '@/components/shared/PageLoader'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -25,6 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
   TableBody,
@@ -93,7 +93,27 @@ export default function ReportsPage() {
     })
   }
 
-  if (isLoading) return <PageLoader />
+  if (isLoading)
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Reports" description="Filter and export your asset data as CSV." />
+        <div className="rounded-md border">
+          <div className="flex items-center gap-2 border-b p-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-24 rounded-md" />
+            ))}
+          </div>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 border-b px-4 py-3 last:border-0">
+              <Skeleton className="h-3.5 w-24" />
+              <Skeleton className="h-3.5 w-40" />
+              <Skeleton className="h-3.5 w-20" />
+              <Skeleton className="h-3.5 w-16" />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
 
   function handleExport() {
     exportAssetsToCsv(assets, 'asset-report.csv', visibleKeys)

--- a/src/app/(app)/orgs/[slug]/users/page.tsx
+++ b/src/app/(app)/orgs/[slug]/users/page.tsx
@@ -8,7 +8,6 @@ import { z } from 'zod'
 
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { PageHeader } from '@/components/shared/PageHeader'
-import { PageLoader } from '@/components/shared/PageLoader'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -45,6 +44,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
   TableBody,
@@ -91,7 +91,24 @@ export default function UsersPage() {
     defaultValues: { email: '', role: 'viewer' },
   })
 
-  if (isLoading) return <PageLoader />
+  if (isLoading)
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Users" />
+        <div className="rounded-md border">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 border-b px-4 py-3 last:border-0">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-3.5 w-32" />
+                <Skeleton className="h-3 w-44" />
+              </div>
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
 
   function openEdit(u: OrgMember) {
     setEditingUser(u)

--- a/src/app/(app)/orgs/[slug]/vendors/page.tsx
+++ b/src/app/(app)/orgs/[slug]/vendors/page.tsx
@@ -8,7 +8,6 @@ import { useForm } from 'react-hook-form'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { PageHeader } from '@/components/shared/PageHeader'
-import { PageLoader } from '@/components/shared/PageLoader'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
@@ -21,6 +20,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Textarea } from '@/components/ui/textarea'
 import { useVendorMutations, useVendors } from '@/lib/hooks/useVendors'
 import { VendorFormSchema, type Vendor, type VendorFormInput } from '@/lib/types'
@@ -38,7 +38,22 @@ export default function VendorsPage() {
     defaultValues: { name: '', contactEmail: '', contactPhone: '', website: '', notes: '' },
   })
 
-  if (isLoading) return <PageLoader />
+  if (isLoading)
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Vendors" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="shadow-sm">
+              <CardContent className="p-4">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="mt-2 h-3 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
 
   function openCreate() {
     setEditing(null)

--- a/src/components/assets/MaintenanceTab.tsx
+++ b/src/components/assets/MaintenanceTab.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useAssetMaintenanceEvents } from '@/lib/hooks/useMaintenance'
 import { createPolicy } from '@/lib/permissions'
 import type { UserRole } from '@/lib/types'
@@ -108,8 +109,23 @@ export function MaintenanceTab({
 
       {/* List */}
       {isLoading ? (
-        <div className="flex justify-center py-12">
-          <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i} className="shadow-sm">
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-2/3" />
+                    <div className="flex gap-2">
+                      <Skeleton className="h-5 w-20 rounded-full" />
+                      <Skeleton className="h-5 w-20 rounded-full" />
+                    </div>
+                  </div>
+                  <Skeleton className="h-8 w-16 rounded-md" />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       ) : events.length === 0 ? (
         <div className="text-muted-foreground flex flex-col items-center gap-2 rounded-xl border py-12 text-center text-sm">


### PR DESCRIPTION
## Summary

- **Skeletons everywhere** — every data-loading state now shows a layout-matched skeleton instead of a centered spinner; button-action spinners (start/complete/delete maintenance) are kept as-is since those are action feedback
- **Asset detail mobile** — action buttons (Check out, Edit, Delete) collapse to icon-only on narrow screens; tab list wrapped in `overflow-x-auto` so the 4 tabs scroll instead of clipping

## Skeleton shapes by page

| Page | Skeleton shape |
|---|---|
| Assets list | Table rows |
| Asset detail (load) | Back area + title/badges + tabs outline + 2 cards |
| Asset detail (history tab) | Audit log rows |
| Asset edit | Page header + 6 form field rows |
| Maintenance page | Table rows |
| Maintenance tab (asset detail) | Event cards with badge pills |
| Dashboard | Greeting + 5 stat cards + 2 chart areas |
| Users | Avatar circle + name/email rows |
| Categories / Departments / Locations / Vendors | 6-card grid |
| Reports | Toolbar + table rows |

## Test plan
- [ ] Visit each page while data loads — no spinner flash, skeleton renders in correct layout shape
- [ ] Asset detail on mobile — buttons show only icons; tabs scroll horizontally
- [ ] Dashboard on slow connection — stat cards skeleton, then real data animates in

🤖 Generated with [Claude Code](https://claude.com/claude-code)