### PR TITLE
fix(types): TypeScript advanced types hardening

### DIFF
--- a/src/app/(app)/orgs/[slug]/settings/org/page.tsx
+++ b/src/app/(app)/orgs/[slug]/settings/org/page.tsx
@@ -108,11 +108,13 @@ const REPORT_COLUMN_TOGGLES: ConfigToggle<ReportConfig>[] = [
 ]
 
 /** Derive a complete config object from stored (possibly partial) values + metadata defaults. */
-function fromConfig<T>(
+function fromConfig<T extends Record<string, boolean>>(
   toggles: ConfigToggle<T>[],
   stored: Partial<T> | null | undefined
-): Record<string, boolean> {
-  return Object.fromEntries(toggles.map((t) => [t.key, (stored?.[t.key] as boolean) ?? t.default]))
+): { [K in keyof T]: boolean } {
+  return Object.fromEntries(toggles.map((t) => [t.key, stored?.[t.key] ?? t.default])) as {
+    [K in keyof T]: boolean
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -362,9 +364,9 @@ export default function OrgSettingsPage() {
       dashboardConfig: {
         ...fromConfig(DASHBOARD_STAT_TOGGLES, null),
         ...fromConfig(DASHBOARD_SECTION_TOGGLES, null),
-      } as OrgFormInput['dashboardConfig'],
-      assetTableConfig: fromConfig(TABLE_COLUMN_TOGGLES, null) as OrgFormInput['assetTableConfig'],
-      reportConfig: fromConfig(REPORT_COLUMN_TOGGLES, null) as OrgFormInput['reportConfig'],
+      },
+      assetTableConfig: fromConfig(TABLE_COLUMN_TOGGLES, null),
+      reportConfig: fromConfig(REPORT_COLUMN_TOGGLES, null),
     },
   })
 
@@ -377,15 +379,9 @@ export default function OrgSettingsPage() {
         dashboardConfig: {
           ...fromConfig(DASHBOARD_STAT_TOGGLES, org.dashboardConfig),
           ...fromConfig(DASHBOARD_SECTION_TOGGLES, org.dashboardConfig),
-        } as OrgFormInput['dashboardConfig'],
-        assetTableConfig: fromConfig(
-          TABLE_COLUMN_TOGGLES,
-          org.assetTableConfig
-        ) as OrgFormInput['assetTableConfig'],
-        reportConfig: fromConfig(
-          REPORT_COLUMN_TOGGLES,
-          org.reportConfig
-        ) as OrgFormInput['reportConfig'],
+        },
+        assetTableConfig: fromConfig(TABLE_COLUMN_TOGGLES, org.assetTableConfig),
+        reportConfig: fromConfig(REPORT_COLUMN_TOGGLES, org.reportConfig),
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -14,8 +14,11 @@ import {
   AssetFormSchema,
   CheckoutFormSchema,
   type AssetFormInput,
+  type AssetId,
+  type AssignmentId,
   type CheckoutFormInput,
   type TypedAsset,
+  type UserId,
 } from '@/lib/types'
 import { nextTagInSequence, sanitizePrefix } from '@/lib/utils/assetTag'
 
@@ -208,10 +211,10 @@ export async function checkoutAsset(
   if (denied) return denied
 
   return checkoutAssetDomain(
-    assetRef.id,
+    assetRef.id as AssetId,
     parsed.data,
     assignedByName,
-    ctx.userId,
+    ctx.userId as UserId,
     createSupabaseCheckoutPorts(ctx)
   )
 }
@@ -235,7 +238,7 @@ export async function returnAsset(
   })
   if (denied) return denied
 
-  return returnSerializedAsset(assetId, createSupabaseCheckoutPorts(ctx))
+  return returnSerializedAsset(assetId as AssetId, createSupabaseCheckoutPorts(ctx))
 }
 
 /** Partially or fully return a bulk assignment */
@@ -268,7 +271,7 @@ export async function returnBulkAssignment(
   if (denied) return denied
 
   return returnBulkAssignmentDomain(
-    assignmentId,
+    assignmentId as AssignmentId,
     quantityToReturn,
     createSupabaseCheckoutPorts(ctx)
   )
@@ -341,8 +344,8 @@ export async function updateAssignment(
   if (denied) return denied
 
   return updateAssignmentDomain(
-    assignmentId,
-    assetRef.id,
+    assignmentId as AssignmentId,
+    assetRef.id as AssetId,
     assetRef.isBulk,
     parsed.data,
     createSupabaseCheckoutPorts(ctx)

--- a/src/app/actions/maintenance.ts
+++ b/src/app/actions/maintenance.ts
@@ -10,6 +10,7 @@ import {
   updateMaintenance,
 } from '@/lib/maintenance'
 import { createPolicy } from '@/lib/permissions'
+import type { AssetId, EventId, OrgId, UserId } from '@/lib/types'
 import {
   CompleteMaintenanceFormSchema,
   MaintenanceFormSchema,
@@ -55,8 +56,8 @@ export async function scheduleMaintenanceAction(
 
   if (parsed.data.isRetroactive) {
     return logRetroactiveMaintenance(
-      ctx.orgId,
-      assetId,
+      ctx.orgId as OrgId,
+      assetId as AssetId,
       {
         title: parsed.data.title,
         type: parsed.data.type,
@@ -67,14 +68,14 @@ export async function scheduleMaintenanceAction(
         technicianName: parsed.data.technicianName ?? null,
         notes: parsed.data.notes ?? null,
       },
-      ctx.userId,
+      ctx.userId as UserId,
       ports
     )
   }
 
   return scheduleMaintenance(
-    ctx.orgId,
-    assetId,
+    ctx.orgId as OrgId,
+    assetId as AssetId,
     {
       title: parsed.data.title,
       type: parsed.data.type,
@@ -82,7 +83,7 @@ export async function scheduleMaintenanceAction(
       technicianName: parsed.data.technicianName ?? null,
       notes: parsed.data.notes ?? null,
     },
-    ctx.userId,
+    ctx.userId as UserId,
     ports
   )
 }
@@ -100,7 +101,7 @@ export async function startMaintenanceAction(
   })
   if (denied) return denied
 
-  return startMaintenance(eventId, createSupabaseMaintenancePorts(ctx))
+  return startMaintenance(eventId as EventId, createSupabaseMaintenancePorts(ctx))
 }
 
 export async function completeMaintenanceAction(
@@ -120,7 +121,7 @@ export async function completeMaintenanceAction(
   })
   if (denied) return denied
 
-  return completeMaintenance(eventId, parsed.data, createSupabaseMaintenancePorts(ctx))
+  return completeMaintenance(eventId as EventId, parsed.data, createSupabaseMaintenancePorts(ctx))
 }
 
 export async function updateMaintenanceAction(
@@ -140,7 +141,7 @@ export async function updateMaintenanceAction(
   if (denied) return denied
 
   return updateMaintenance(
-    eventId,
+    eventId as EventId,
     {
       title: parsed.data.title,
       type: parsed.data.type,
@@ -167,5 +168,10 @@ export async function deleteMaintenanceAction(
 
   const isAdmin = policy.can('department:manage')
 
-  return deleteMaintenance(eventId, ctx.userId, isAdmin, createSupabaseMaintenancePorts(ctx))
+  return deleteMaintenance(
+    eventId as EventId,
+    ctx.userId as UserId,
+    isAdmin,
+    createSupabaseMaintenancePorts(ctx)
+  )
 }

--- a/src/lib/checkout/__tests__/checkout.test.ts
+++ b/src/lib/checkout/__tests__/checkout.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import type { CheckoutFormInput } from '@/lib/types'
+import type { AssetId, AssignmentId, CheckoutFormInput, UserId } from '@/lib/types'
 
 import {
   checkoutAsset,
@@ -16,8 +16,8 @@ import { InMemoryCheckoutRepo, SpyAuditPort } from './fakes'
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ASSET_ID = 'asset-001'
-const ACTOR_ID = 'user-001'
+const ASSET_ID = 'asset-001' as AssetId
+const ACTOR_ID = 'user-001' as UserId
 
 function makePorts(repo: InMemoryCheckoutRepo, audit = new SpyAuditPort()): CheckoutPorts {
   return { repo, audit }
@@ -51,7 +51,13 @@ describe('checkoutAsset', () => {
 
   it('returns error when asset is not found', async () => {
     const ports = makePorts(repo, audit)
-    const result = await checkoutAsset('nonexistent', makeInput(), 'Admin', ACTOR_ID, ports)
+    const result = await checkoutAsset(
+      'nonexistent' as AssetId,
+      makeInput(),
+      'Admin',
+      ACTOR_ID,
+      ports
+    )
     expect(result).toEqual({ error: 'Asset not found.' })
   })
 
@@ -255,7 +261,7 @@ describe('returnSerializedAsset', () => {
 describe('returnBulkAssignment', () => {
   let repo: InMemoryCheckoutRepo
   let audit: SpyAuditPort
-  let assignmentId: string
+  let assignmentId: AssignmentId
 
   beforeEach(async () => {
     repo = new InMemoryCheckoutRepo()
@@ -279,11 +285,15 @@ describe('returnBulkAssignment', () => {
       expectedReturnAt: null,
       notes: null,
     })
-    assignmentId = id
+    assignmentId = id as AssignmentId
   })
 
   it('returns error when assignment not found', async () => {
-    const result = await returnBulkAssignment('nonexistent', 1, makePorts(repo, audit))
+    const result = await returnBulkAssignment(
+      'nonexistent' as AssignmentId,
+      1,
+      makePorts(repo, audit)
+    )
     expect(result).toEqual({ error: 'Assignment not found.' })
   })
 
@@ -322,7 +332,7 @@ describe('returnBulkAssignment', () => {
 describe('updateAssignment', () => {
   let repo: InMemoryCheckoutRepo
   let audit: SpyAuditPort
-  let assignmentId: string
+  let assignmentId: AssignmentId
 
   beforeEach(async () => {
     repo = new InMemoryCheckoutRepo()
@@ -359,7 +369,7 @@ describe('updateAssignment', () => {
       expectedReturnAt: null,
       notes: null,
     })
-    assignmentId = id
+    assignmentId = id as AssignmentId
   })
 
   it('updates the assignment name and logs audit', async () => {
@@ -448,7 +458,13 @@ describe('updateAssignment', () => {
       notes: null,
     })
     const ports = makePorts(repo, audit)
-    const result = await updateAssignment(id, 'serial-01', false, makeInput({ quantity: 1 }), ports)
+    const result = await updateAssignment(
+      id as AssignmentId,
+      'serial-01' as AssetId,
+      false,
+      makeInput({ quantity: 1 }),
+      ports
+    )
     expect(result).toBeNull()
   })
 })

--- a/src/lib/checkout/domain.ts
+++ b/src/lib/checkout/domain.ts
@@ -1,3 +1,4 @@
+import type { AssetId, AssignmentId, UserId } from '@/lib/types'
 import type { CheckoutFormInput } from '@/lib/types'
 import { computeAvailable } from '@/lib/utils/availability'
 
@@ -10,10 +11,10 @@ export type DomainResult = { error: string } | null
 // ---------------------------------------------------------------------------
 
 export async function checkoutAsset(
-  assetId: string,
+  assetId: AssetId,
   input: CheckoutFormInput,
   assignedByName: string,
-  actorId: string,
+  actorId: UserId,
   ports: CheckoutPorts
 ): Promise<DomainResult> {
   const asset = await ports.repo.getAsset(assetId)
@@ -77,7 +78,7 @@ export async function checkoutAsset(
 // ---------------------------------------------------------------------------
 
 export async function returnSerializedAsset(
-  assetId: string,
+  assetId: AssetId,
   ports: CheckoutPorts
 ): Promise<DomainResult> {
   const [assignment, asset] = await Promise.all([
@@ -106,7 +107,7 @@ export async function returnSerializedAsset(
 // ---------------------------------------------------------------------------
 
 export async function returnBulkAssignment(
-  assignmentId: string,
+  assignmentId: AssignmentId,
   quantityToReturn: number,
   ports: CheckoutPorts
 ): Promise<DomainResult> {
@@ -140,8 +141,8 @@ export async function returnBulkAssignment(
 // ---------------------------------------------------------------------------
 
 export async function updateAssignment(
-  assignmentId: string,
-  assetId: string,
+  assignmentId: AssignmentId,
+  assetId: AssetId,
   isBulk: boolean,
   input: CheckoutFormInput,
   ports: CheckoutPorts

--- a/src/lib/hooks/useAssets.ts
+++ b/src/lib/hooks/useAssets.ts
@@ -205,6 +205,7 @@ export type PaginatedAssets = {
   data: TypedAsset[]
   totalCount: number
   isLoading: boolean
+  isError: boolean
   refresh: () => void
 }
 
@@ -226,7 +227,7 @@ export function useAssets(filters: AssetFilters = {}, page = 1, pageSize = 25): 
     pageSize,
   ]
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey,
     enabled: !!orgId,
     queryFn: async () => {
@@ -276,6 +277,7 @@ export function useAssets(filters: AssetFilters = {}, page = 1, pageSize = 25): 
     data: (data?.rows ?? []).map(mapAssetRow),
     totalCount: data?.count ?? 0,
     isLoading,
+    isError,
     refresh,
   }
 }
@@ -287,12 +289,13 @@ export function useAssets(filters: AssetFilters = {}, page = 1, pageSize = 25): 
 export function useAsset(id: string): {
   data: TypedAsset | null
   isLoading: boolean
+  isError: boolean
   refresh: () => void
 } {
   const { user } = useAuth()
   const queryClient = useQueryClient()
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: ['asset', id],
     enabled: !!user?.id && !!id,
     queryFn: async () => {
@@ -320,7 +323,7 @@ export function useAsset(id: string): {
     ])
   }, [queryClient, id])
 
-  return { data: data ?? null, isLoading, refresh }
+  return { data: data ?? null, isLoading, isError, refresh }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/hooks/useAuditLogs.ts
+++ b/src/lib/hooks/useAuditLogs.ts
@@ -4,29 +4,46 @@ import { createClient } from '@/lib/supabase/client'
 import type { AuditLog } from '@/lib/types'
 import { useOrg } from '@/providers/OrgProvider'
 
-function mapLog(r: Record<string, unknown>): AuditLog {
+type AuditLogRow = {
+  id: string
+  org_id: string
+  actor_id: string | null
+  actor_name: string
+  entity_type: string
+  entity_id: string
+  entity_name: string
+  action: string
+  changes: Record<string, { old: unknown; new: unknown }> | null
+  created_at: string
+}
+
+function mapLog(r: AuditLogRow): AuditLog {
   return {
-    id: r.id as string,
-    orgId: r.org_id as string,
-    actorId: (r.actor_id as string) ?? '',
-    actorName: r.actor_name as string,
+    id: r.id,
+    orgId: r.org_id,
+    actorId: r.actor_id ?? '',
+    actorName: r.actor_name,
     entityType: r.entity_type as AuditLog['entityType'],
-    entityId: r.entity_id as string,
-    entityName: r.entity_name as string,
+    entityId: r.entity_id,
+    entityName: r.entity_name,
     action: r.action as AuditLog['action'],
-    changes: (r.changes as AuditLog['changes']) ?? null,
-    createdAt: r.created_at as string,
+    changes: r.changes,
+    createdAt: r.created_at,
   }
 }
 
 export function useRecentActivity(
   limit = 10,
   enabled = true
-): { data: AuditLog[]; isLoading: boolean } {
+): { data: AuditLog[]; isLoading: boolean; isError: boolean } {
   const { org } = useOrg()
   const orgId = org?.id ?? ''
 
-  const { data = [], isLoading } = useQuery({
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['recentActivity', orgId, limit],
     enabled: !!orgId && enabled,
     queryFn: async () => {
@@ -36,22 +53,27 @@ export function useRecentActivity(
         .eq('org_id', orgId)
         .order('created_at', { ascending: false })
         .limit(limit)
-      return (rows ?? []).map(mapLog)
+      return ((rows ?? []) as AuditLogRow[]).map(mapLog)
     },
     staleTime: 30_000,
   })
 
-  return { data, isLoading }
+  return { data, isLoading, isError }
 }
 
 export function useAssetHistory(assetId: string): {
   data: AuditLog[]
   isLoading: boolean
+  isError: boolean
 } {
   const { org } = useOrg()
   const orgId = org?.id ?? ''
 
-  const { data = [], isLoading } = useQuery({
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['assetHistory', assetId],
     enabled: !!orgId && !!assetId,
     queryFn: async () => {
@@ -61,10 +83,10 @@ export function useAssetHistory(assetId: string): {
         .eq('org_id', orgId)
         .eq('entity_id', assetId)
         .order('created_at', { ascending: false })
-      return (rows ?? []).map(mapLog)
+      return ((rows ?? []) as AuditLogRow[]).map(mapLog)
     },
     staleTime: 30_000,
   })
 
-  return { data, isLoading }
+  return { data, isLoading, isError }
 }

--- a/src/lib/hooks/useMaintenance.ts
+++ b/src/lib/hooks/useMaintenance.ts
@@ -6,37 +6,61 @@ import { createClient } from '@/lib/supabase/client'
 import type { MaintenanceEvent, MaintenanceStatus, MaintenanceType } from '@/lib/types/maintenance'
 import { useOrg } from '@/providers/OrgProvider'
 
-function mapEvent(r: Record<string, unknown>): MaintenanceEvent {
+type MaintenanceEventRow = {
+  id: string
+  org_id: string
+  asset_id: string
+  title: string
+  type: string
+  status: string
+  scheduled_date: string
+  started_at: string | null
+  completed_at: string | null
+  cost: number | null
+  technician_name: string | null
+  notes: string | null
+  created_by: string | null
+  deleted_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+function mapEvent(r: MaintenanceEventRow): MaintenanceEvent {
   return {
-    id: r.id as string,
-    orgId: r.org_id as string,
-    assetId: r.asset_id as string,
-    title: r.title as string,
+    id: r.id,
+    orgId: r.org_id,
+    assetId: r.asset_id,
+    title: r.title,
     type: r.type as MaintenanceEvent['type'],
     status: r.status as MaintenanceEvent['status'],
-    scheduledDate: r.scheduled_date as string,
-    startedAt: (r.started_at as string) ?? null,
-    completedAt: (r.completed_at as string) ?? null,
-    cost: (r.cost as number) ?? null,
-    technicianName: (r.technician_name as string) ?? null,
-    notes: (r.notes as string) ?? null,
-    createdBy: (r.created_by as string) ?? null,
-    deletedAt: (r.deleted_at as string) ?? null,
-    createdAt: r.created_at as string,
-    updatedAt: r.updated_at as string,
+    scheduledDate: r.scheduled_date,
+    startedAt: r.started_at,
+    completedAt: r.completed_at,
+    cost: r.cost,
+    technicianName: r.technician_name,
+    notes: r.notes,
+    createdBy: r.created_by,
+    deletedAt: r.deleted_at,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
   }
 }
 
 export function useAssetMaintenanceEvents(assetId: string): {
   data: MaintenanceEvent[]
   isLoading: boolean
+  isError: boolean
   refresh: () => void
 } {
   const { org } = useOrg()
   const orgId = org?.id ?? ''
   const queryClient = useQueryClient()
 
-  const { data = [], isLoading } = useQuery({
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['maintenanceEvents', assetId],
     enabled: !!orgId && !!assetId,
     queryFn: async () => {
@@ -46,7 +70,7 @@ export function useAssetMaintenanceEvents(assetId: string): {
         .eq('asset_id', assetId)
         .is('deleted_at', null)
         .order('created_at', { ascending: false })
-      return (rows ?? []).map(mapEvent)
+      return ((rows ?? []) as MaintenanceEventRow[]).map(mapEvent)
     },
     staleTime: 30_000,
   })
@@ -55,7 +79,7 @@ export function useAssetMaintenanceEvents(assetId: string): {
     void queryClient.invalidateQueries({ queryKey: ['maintenanceEvents', assetId] })
   }, [queryClient, assetId])
 
-  return { data, isLoading, refresh }
+  return { data, isLoading, isError, refresh }
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +102,7 @@ export type MaintenanceListItem = MaintenanceEvent & {
 export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
   data: MaintenanceListItem[]
   isLoading: boolean
+  isError: boolean
   refresh: () => void
 } {
   const { org, role, departmentIds } = useOrg()
@@ -86,7 +111,11 @@ export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
 
   const constraint = createPolicy({ role: role ?? 'viewer', departmentIds }).queryConstraint()
 
-  const { data = [], isLoading } = useQuery({
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: [
       'maintenanceList',
       orgId,
@@ -133,7 +162,7 @@ export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
 
       const { data: rows } = await query
 
-      type MaintenanceRow = Record<string, unknown> & {
+      type MaintenanceListRow = MaintenanceEventRow & {
         assets: {
           name: string
           asset_tag: string
@@ -141,7 +170,7 @@ export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
         }
       }
 
-      return ((rows ?? []) as MaintenanceRow[]).map((r) => ({
+      return ((rows ?? []) as MaintenanceListRow[]).map((r) => ({
         ...mapEvent(r),
         assetName: r.assets.name,
         assetTag: r.assets.asset_tag,
@@ -155,5 +184,5 @@ export function useMaintenanceList(filters: MaintenanceListFilters = {}): {
     void queryClient.invalidateQueries({ queryKey: ['maintenanceList'] })
   }, [queryClient])
 
-  return { data, isLoading, refresh }
+  return { data, isLoading, isError, refresh }
 }

--- a/src/lib/hooks/useOrgUsers.ts
+++ b/src/lib/hooks/useOrgUsers.ts
@@ -36,7 +36,18 @@ type UDRow = {
   departments: { id: string; name: string } | null
 }
 
-type InvRow = Record<string, unknown>
+type InvRow = {
+  id: string
+  org_id: string
+  email: string
+  role: string
+  token: string
+  invited_by: string | null
+  invited_by_name: string
+  accepted_at: string | null
+  expires_at: string
+  created_at: string
+}
 
 async function fetchOrgUsers(
   orgId: string
@@ -67,13 +78,13 @@ async function fetchOrgUsers(
   if (invsResult.error) throw new Error(invsResult.error.message)
 
   const deptsByUser = new Map<string, UDRow[]>()
-  for (const ud of (deptsResult.data ?? []) as unknown as UDRow[]) {
+  for (const ud of deptsResult.data as UDRow[]) {
     const arr = deptsByUser.get(ud.user_id) ?? []
     arr.push(ud)
     deptsByUser.set(ud.user_id, arr)
   }
 
-  const users = ((membershipsResult.data ?? []) as unknown as MembershipRow[]).map((m) => {
+  const users = (membershipsResult.data as MembershipRow[]).map((m) => {
     const p = m.profiles
     const depts = deptsByUser.get(m.user_id) ?? []
     return {
@@ -83,7 +94,7 @@ async function fetchOrgUsers(
       email: p?.email ?? '',
       avatarUrl: p?.avatar_url ?? null,
       role: m.role as OrgMember['role'],
-      inviteStatus: m.invite_status,
+      inviteStatus: m.invite_status as OrgMember['inviteStatus'],
       createdAt: p?.created_at ?? '',
       updatedAt: p?.updated_at ?? '',
       departmentIds: depts.map((ud) => ud.department_id),
@@ -91,17 +102,17 @@ async function fetchOrgUsers(
     }
   })
 
-  const pendingInvites = ((invsResult.data ?? []) as InvRow[]).map((r) => ({
-    id: r.id as string,
-    orgId: r.org_id as string,
-    email: r.email as string,
+  const pendingInvites = (invsResult.data as InvRow[]).map((r) => ({
+    id: r.id,
+    orgId: r.org_id,
+    email: r.email,
     role: r.role as Invite['role'],
-    token: r.token as string,
-    invitedBy: (r.invited_by as string) ?? '',
-    invitedByName: r.invited_by_name as string,
+    token: r.token,
+    invitedBy: r.invited_by ?? '',
+    invitedByName: r.invited_by_name,
     acceptedAt: null,
-    expiresAt: r.expires_at as string,
-    createdAt: r.created_at as string,
+    expiresAt: r.expires_at,
+    createdAt: r.created_at,
   }))
 
   return { users, pendingInvites }
@@ -120,6 +131,7 @@ export function useOrgUsers() {
     users: query.data?.users ?? [],
     pendingInvites: query.data?.pendingInvites ?? [],
     isLoading: query.isLoading,
+    isError: query.isError,
   }
 }
 

--- a/src/lib/hooks/useUpcomingMaintenanceAlerts.ts
+++ b/src/lib/hooks/useUpcomingMaintenanceAlerts.ts
@@ -4,7 +4,11 @@ import { createClient } from '@/lib/supabase/client'
 import type { UpcomingMaintenanceAlert } from '@/lib/types'
 import { useOrg } from '@/providers/OrgProvider'
 
-type MaintenanceRow = Record<string, unknown> & {
+type MaintenanceRow = {
+  id: string
+  asset_id: string
+  title: string
+  scheduled_date: string
   assets: { asset_tag: string; name: string; departments: { name: string } | null }
 }
 
@@ -12,7 +16,11 @@ export function useUpcomingMaintenanceAlerts(limit = 8, enabled = true) {
   const { org } = useOrg()
   const orgId = org?.id
 
-  const { data = [], isLoading } = useQuery({
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['upcomingMaintenanceAlerts', orgId, limit],
     enabled: orgId != null && enabled,
     queryFn: async () => {
@@ -34,20 +42,20 @@ export function useUpcomingMaintenanceAlerts(limit = 8, enabled = true) {
 
       const now = new Date()
       return ((rows ?? []) as MaintenanceRow[]).map((r) => ({
-        eventId: r.id as string,
-        assetId: r.asset_id as string,
+        eventId: r.id,
+        assetId: r.asset_id,
         assetTag: r.assets.asset_tag,
         assetName: r.assets.name,
         departmentName: r.assets.departments?.name ?? null,
-        title: r.title as string,
-        scheduledDate: r.scheduled_date as string,
+        title: r.title,
+        scheduledDate: r.scheduled_date,
         daysUntil: Math.ceil(
-          (new Date(r.scheduled_date as string).getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+          (new Date(r.scheduled_date).getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
         ),
       })) satisfies UpcomingMaintenanceAlert[]
     },
     staleTime: 60_000,
   })
 
-  return { data, isLoading }
+  return { data, isLoading, isError }
 }

--- a/src/lib/hooks/useWarrantyAlerts.ts
+++ b/src/lib/hooks/useWarrantyAlerts.ts
@@ -8,7 +8,11 @@ export function useWarrantyAlerts(limit = 8, enabled = true) {
   const { org } = useOrg()
   const orgId = org?.id
 
-  const { data = [], isLoading } = useQuery({
+  const {
+    data = [],
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['warrantyAlerts', orgId, limit],
     enabled: orgId != null && enabled,
     queryFn: async () => {
@@ -24,20 +28,28 @@ export function useWarrantyAlerts(limit = 8, enabled = true) {
         .order('warranty_expiry')
         .limit(limit)
 
+      type WarrantyRow = {
+        id: string
+        asset_tag: string
+        name: string
+        warranty_expiry: string
+        departments: { name: string } | null
+      }
+
       const now = new Date()
-      return ((rows ?? []) as Record<string, unknown>[]).map((r) => ({
-        assetId: r.id as string,
-        assetTag: r.asset_tag as string,
-        assetName: r.name as string,
-        departmentName: (r.departments as { name: string } | null)?.name ?? null,
-        warrantyExpiry: r.warranty_expiry as string,
+      return ((rows ?? []) as WarrantyRow[]).map((r) => ({
+        assetId: r.id,
+        assetTag: r.asset_tag,
+        assetName: r.name,
+        departmentName: r.departments?.name ?? null,
+        warrantyExpiry: r.warranty_expiry,
         daysRemaining: Math.ceil(
-          (new Date(r.warranty_expiry as string).getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+          (new Date(r.warranty_expiry).getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
         ),
       })) satisfies WarrantyAlert[]
     },
     staleTime: 60_000,
   })
 
-  return { data, isLoading }
+  return { data, isLoading, isError }
 }

--- a/src/lib/maintenance/__tests__/domain.test.ts
+++ b/src/lib/maintenance/__tests__/domain.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import type { AssetId, EventId, OrgId, UserId } from '@/lib/types'
+
 import {
   completeMaintenance,
   logRetroactiveMaintenance,
@@ -14,9 +16,10 @@ import { InMemoryMaintenanceRepo, SpyMaintenanceAuditPort } from './fakes'
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ORG_ID = 'org-001'
-const ASSET_ID = 'asset-001'
-const USER_ID = 'user-001'
+const ORG_ID = 'org-001' as OrgId
+const ASSET_ID = 'asset-001' as AssetId
+const USER_ID = 'user-001' as UserId
+const EVENT_ID = 'evt-001' as EventId
 
 function makePorts(
   repo: InMemoryMaintenanceRepo,
@@ -66,7 +69,7 @@ describe('scheduleMaintenance', () => {
   it('returns error when asset is not found', async () => {
     const result = await scheduleMaintenance(
       ORG_ID,
-      'nonexistent',
+      'nonexistent' as AssetId,
       makeScheduleInput(),
       USER_ID,
       makePorts(repo, audit)
@@ -239,7 +242,7 @@ describe('logRetroactiveMaintenance', () => {
   it('returns error when asset is not found', async () => {
     const result = await logRetroactiveMaintenance(
       ORG_ID,
-      'nonexistent',
+      'nonexistent' as AssetId,
       makeRetroactiveInput(),
       USER_ID,
       makePorts(repo, audit)
@@ -325,7 +328,7 @@ describe('startMaintenance', () => {
   }
 
   it('returns error when event is not found', async () => {
-    const result = await startMaintenance('nonexistent', makePorts(repo, audit))
+    const result = await startMaintenance('nonexistent' as EventId, makePorts(repo, audit))
     expect(result).toEqual({ error: 'Maintenance event not found.' })
   })
 
@@ -346,27 +349,27 @@ describe('startMaintenance', () => {
       createdBy: USER_ID,
       deletedAt: null,
     })
-    const result = await startMaintenance('evt-001', makePorts(repo, audit))
+    const result = await startMaintenance(EVENT_ID, makePorts(repo, audit))
     expect(result).toEqual({ error: 'Only scheduled events can be started.' })
   })
 
   it('returns error when asset is checked_out', async () => {
     seedScheduledEvent()
     repo.assetStatuses.set(ASSET_ID, 'checked_out')
-    const result = await startMaintenance('evt-001', makePorts(repo, audit))
+    const result = await startMaintenance(EVENT_ID, makePorts(repo, audit))
     expect(result).toEqual({ error: 'Return the asset before starting maintenance.' })
   })
 
   it('returns error when asset is retired', async () => {
     seedScheduledEvent()
     repo.assetStatuses.set(ASSET_ID, 'retired')
-    const result = await startMaintenance('evt-001', makePorts(repo, audit))
+    const result = await startMaintenance(EVENT_ID, makePorts(repo, audit))
     expect(result).toEqual({ error: 'Cannot start maintenance on a retired asset.' })
   })
 
   it('sets event to in_progress and asset to under_maintenance on success', async () => {
     seedScheduledEvent()
-    const result = await startMaintenance('evt-001', makePorts(repo, audit))
+    const result = await startMaintenance(EVENT_ID, makePorts(repo, audit))
 
     expect(result).toBeNull()
     expect(repo.events.get('evt-001')!.status).toBe('in_progress')
@@ -420,7 +423,7 @@ describe('completeMaintenance', () => {
 
   it('returns error when event is not found', async () => {
     const result = await completeMaintenance(
-      'nonexistent',
+      'nonexistent' as EventId,
       makeCompleteInput(),
       makePorts(repo, audit)
     )
@@ -429,12 +432,12 @@ describe('completeMaintenance', () => {
 
   it('returns error when event is not in_progress', async () => {
     repo.events.get('evt-001')!.status = 'scheduled'
-    const result = await completeMaintenance('evt-001', makeCompleteInput(), makePorts(repo, audit))
+    const result = await completeMaintenance(EVENT_ID, makeCompleteInput(), makePorts(repo, audit))
     expect(result).toEqual({ error: 'Only in-progress events can be completed.' })
   })
 
   it('sets event to completed and restores asset to active', async () => {
-    const result = await completeMaintenance('evt-001', makeCompleteInput(), makePorts(repo, audit))
+    const result = await completeMaintenance(EVENT_ID, makeCompleteInput(), makePorts(repo, audit))
 
     expect(result).toBeNull()
     expect(repo.events.get('evt-001')!.status).toBe('completed')
@@ -447,7 +450,7 @@ describe('completeMaintenance', () => {
 
   it('persists cost, technicianName, and notes on completion', async () => {
     await completeMaintenance(
-      'evt-001',
+      EVENT_ID,
       makeCompleteInput({ cost: 350, technicianName: 'Bob', notes: 'Fixed leak' }),
       makePorts(repo, audit)
     )
@@ -460,7 +463,7 @@ describe('completeMaintenance', () => {
   it('does not overwrite asset status if asset is no longer under_maintenance', async () => {
     // Simulate a concurrent state change (e.g. someone manually changed status)
     repo.assetStatuses.set(ASSET_ID, 'checked_out')
-    const result = await completeMaintenance('evt-001', makeCompleteInput(), makePorts(repo, audit))
+    const result = await completeMaintenance(EVENT_ID, makeCompleteInput(), makePorts(repo, audit))
 
     expect(result).toBeNull()
     // Asset status should not have been touched
@@ -468,12 +471,12 @@ describe('completeMaintenance', () => {
   })
 
   it('includes cost in audit changes when provided', async () => {
-    await completeMaintenance('evt-001', makeCompleteInput({ cost: 500 }), makePorts(repo, audit))
+    await completeMaintenance(EVENT_ID, makeCompleteInput({ cost: 500 }), makePorts(repo, audit))
     expect(audit.calls[0]!.changes).toMatchObject({ cost: { old: null, new: 500 } })
   })
 
   it('omits cost from audit changes when not provided', async () => {
-    await completeMaintenance('evt-001', makeCompleteInput({ cost: null }), makePorts(repo, audit))
+    await completeMaintenance(EVENT_ID, makeCompleteInput({ cost: null }), makePorts(repo, audit))
     expect(audit.calls[0]!.changes).not.toHaveProperty('cost')
   })
 })

--- a/src/lib/maintenance/domain.ts
+++ b/src/lib/maintenance/domain.ts
@@ -1,3 +1,4 @@
+import type { AssetId, EventId, OrgId, UserId } from '@/lib/types'
 import type { MaintenanceType } from '@/lib/types/maintenance'
 
 import type { CompleteMaintenanceData, MaintenancePorts, UpdateMaintenanceData } from './ports'
@@ -35,10 +36,10 @@ export type RetroactiveInput = {
 // ---------------------------------------------------------------------------
 
 export async function scheduleMaintenance(
-  orgId: string,
-  assetId: string,
+  orgId: OrgId,
+  assetId: AssetId,
   input: ScheduleInput,
-  createdBy: string,
+  createdBy: UserId,
   ports: MaintenancePorts
 ): Promise<DomainResult> {
   const asset = await ports.repo.getAsset(assetId)
@@ -90,10 +91,10 @@ export async function scheduleMaintenance(
 // ---------------------------------------------------------------------------
 
 export async function logRetroactiveMaintenance(
-  orgId: string,
-  assetId: string,
+  orgId: OrgId,
+  assetId: AssetId,
   input: RetroactiveInput,
-  createdBy: string,
+  createdBy: UserId,
   ports: MaintenancePorts
 ): Promise<DomainResult> {
   const asset = await ports.repo.getAsset(assetId)
@@ -143,7 +144,7 @@ export async function logRetroactiveMaintenance(
 // ---------------------------------------------------------------------------
 
 export async function startMaintenance(
-  eventId: string,
+  eventId: EventId,
   ports: MaintenancePorts
 ): Promise<DomainResult> {
   const event = await ports.repo.getEvent(eventId)
@@ -188,7 +189,7 @@ export async function startMaintenance(
 // ---------------------------------------------------------------------------
 
 export async function completeMaintenance(
-  eventId: string,
+  eventId: EventId,
   input: CompleteMaintenanceData,
   ports: MaintenancePorts
 ): Promise<DomainResult> {
@@ -232,7 +233,7 @@ export async function completeMaintenance(
 // ---------------------------------------------------------------------------
 
 export async function updateMaintenance(
-  eventId: string,
+  eventId: EventId,
   input: UpdateMaintenanceData,
   ports: MaintenancePorts
 ): Promise<DomainResult> {
@@ -264,8 +265,8 @@ export async function updateMaintenance(
 // ---------------------------------------------------------------------------
 
 export async function deleteMaintenance(
-  eventId: string,
-  requesterId: string,
+  eventId: EventId,
+  requesterId: UserId,
   isAdmin: boolean,
   ports: MaintenancePorts
 ): Promise<DomainResult> {

--- a/src/lib/maintenance/ports.ts
+++ b/src/lib/maintenance/ports.ts
@@ -1,5 +1,5 @@
 import type { AssetStatus } from '@/lib/types'
-import type { MaintenanceStatus } from '@/lib/types/maintenance'
+import type { MaintenanceStatus, MaintenanceType } from '@/lib/types/maintenance'
 
 // ---------------------------------------------------------------------------
 // Shared record types — camelCase, no Supabase noise
@@ -23,7 +23,7 @@ export type InsertMaintenanceData = {
   orgId: string
   assetId: string
   title: string
-  type: string
+  type: MaintenanceType
   status: MaintenanceStatus
   scheduledDate: string
   startedAt: string | null
@@ -43,7 +43,7 @@ export type CompleteMaintenanceData = {
 
 export type UpdateMaintenanceData = {
   title: string
-  type: string
+  type: MaintenanceType
   scheduledDate: string
   cost: number | null
   technicianName: string | null

--- a/src/lib/types/asset.ts
+++ b/src/lib/types/asset.ts
@@ -84,40 +84,40 @@ export type AssetAssignment = z.infer<typeof AssetAssignmentSchema>
 // ---------------------------------------------------------------------------
 
 type AssetRelations = {
-  categoryName: string | null
-  departmentName: string | null
-  locationName: string | null
-  vendorName: string | null
+  readonly categoryName: string | null
+  readonly departmentName: string | null
+  readonly locationName: string | null
+  readonly vendorName: string | null
 }
 
 /** Pre-computed view-layer fields — eliminates isBulk branching in UI components. */
 export type AssetUI = {
   /** null = render <AssetStatusBadge>; string = render <Badge variant="secondary"> */
-  statusBadgeText: string | null
+  readonly statusBadgeText: string | null
   /** "items" for bulk, "asset" for serialized — used in CheckoutModal title */
-  checkoutLabel: 'items' | 'asset'
+  readonly checkoutLabel: 'items' | 'asset'
   /** "— 4 available" for bulk, "— TAG-001" for serialized */
-  checkoutSubtitle: string
+  readonly checkoutSubtitle: string
   /** null = don't render quantity field; number = max for the quantity input */
-  availableQty: number | null
+  readonly availableQty: number | null
   /** "Checked out (3)" for bulk, "Assignment" for serialized */
-  assignmentTabLabel: string
+  readonly assignmentTabLabel: string
   /** Which secondary action button to show in the detail header */
-  secondaryAction: 'restock' | 'return' | null
+  readonly secondaryAction: 'restock' | 'return' | null
   /** Normalized assignment list — serialized gets [] or [currentAssignment] */
-  assignments: AssetAssignment[]
+  readonly assignments: readonly AssetAssignment[]
 }
 
 /** Pre-computed display fields available on every asset regardless of kind. */
 type AssetDisplay = {
   /** "Alice" for serialized, "Alice +2 others" for bulk with multiple, null if unassigned. */
-  assigneeSummary: string | null
+  readonly assigneeSummary: string | null
   /** "3/10 avail." for bulk; ASSET_STATUS_LABELS value for serialized. */
-  statusLabel: string
+  readonly statusLabel: string
   /** True if the asset can be checked out right now — uniform gate, no branching needed. */
-  isAvailable: boolean
-  isCheckedOut: boolean
-  ui: AssetUI
+  readonly isAvailable: boolean
+  readonly isCheckedOut: boolean
+  readonly ui: AssetUI
 }
 
 export type BulkAsset = Asset &

--- a/src/lib/types/audit.ts
+++ b/src/lib/types/audit.ts
@@ -27,7 +27,7 @@ export const AuditLogSchema = z.object({
   orgId: z.string().uuid(),
   actorId: z.string().uuid(),
   actorName: z.string(),
-  entityType: z.enum(['asset', 'user', 'department', 'category', 'location', 'vendor']),
+  entityType: z.enum(['asset', 'user', 'department', 'category', 'location', 'vendor', 'org']),
   entityId: z.string().uuid(),
   entityName: z.string(),
   action: AuditActionSchema,

--- a/src/lib/types/common.ts
+++ b/src/lib/types/common.ts
@@ -1,6 +1,20 @@
 import { z } from 'zod'
 
 // ---------------------------------------------------------------------------
+// Branded / opaque ID types
+// ---------------------------------------------------------------------------
+
+declare const __brand: unique symbol
+type Brand<T, B> = T & { [__brand]: B }
+
+export type OrgId = Brand<string, 'OrgId'>
+export type AssetId = Brand<string, 'AssetId'>
+export type UserId = Brand<string, 'UserId'>
+export type DeptId = Brand<string, 'DeptId'>
+export type EventId = Brand<string, 'EventId'>
+export type AssignmentId = Brand<string, 'AssignmentId'>
+
+// ---------------------------------------------------------------------------
 // Pagination
 // ---------------------------------------------------------------------------
 
@@ -13,17 +27,30 @@ export const PaginationSchema = z.object({
 export type Pagination = z.infer<typeof PaginationSchema>
 
 export type PaginatedResult<T> = {
-  data: T[]
-  pagination: Pagination
+  readonly data: readonly T[]
+  readonly pagination: Pagination
 }
 
 // ---------------------------------------------------------------------------
 // API response wrapper (for Phase 2 compatibility)
 // ---------------------------------------------------------------------------
 
-export type ApiSuccess<T> = { success: true; data: T }
-export type ApiError = { success: false; error: string }
+export type ApiSuccess<T> = { readonly success: true; readonly data: T }
+export type ApiError = { readonly success: false; readonly error: string }
 export type ApiResponse<T> = ApiSuccess<T> | ApiError
+
+// ---------------------------------------------------------------------------
+// Sort / filter helpers
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Async state discriminated union
+// ---------------------------------------------------------------------------
+
+export type AsyncState<T> =
+  | { status: 'loading' }
+  | { status: 'error'; error: string }
+  | { status: 'success'; data: T }
 
 // ---------------------------------------------------------------------------
 // Sort / filter helpers

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -111,7 +111,7 @@ export type ProfileWithDepartments = Profile & {
 export type OrgMember = Profile & {
   orgId: string
   role: UserRole
-  inviteStatus: string
+  inviteStatus: InviteStatus
   departmentIds: string[]
   departmentNames: string[]
 }


### PR DESCRIPTION
## Summary

Addresses all findings from the TypeScript advanced types audit across the full type system — correctness bugs, unsafe casts, missing narrowing, and structural improvements.

**Correctness bugs fixed**
- `'org'` was accepted by `logAudit` as a valid `EntityType` but missing from the `AuditLog` Zod schema — org-scoped audit entries wrote successfully but failed validation on read-back
- `OrgMember.inviteStatus` typed as `string` instead of the existing `InviteStatus` union
- `InsertMaintenanceData.type` / `UpdateMaintenanceData.type` typed as `string` instead of `MaintenanceType`

**Unsafe casts eliminated**
- Replaced `Record<string, unknown>` + mass `as string` row mappers with typed row interfaces in `useMaintenance`, `useAuditLogs`, `useWarrantyAlerts`, `useUpcomingMaintenanceAlerts`
- Eliminated `as unknown as` double-casts in `useOrgUsers` — `MembershipRow` and `UDRow` types were already correct, Supabase inferred type just needed a single-level cast
- Typed `InvRow` in `useOrgUsers` (was `Record<string, unknown>`)
- Removed redundant `as boolean` / `as OrgFormInput[...]` casts from `fromConfig` callsites

**Type improvements**
- `fromConfig<T>` constrained to `T extends Record<string, boolean>` with mapped return type `{ [K in keyof T]: boolean }` — return type now carries key information
- Added `AsyncState<T>` discriminated union to `common.ts`
- All hooks now expose `isError: boolean` — disambiguates `null` meaning "loading" vs "404/error"
- Added `readonly` to `AssetRelations`, `AssetUI`, `AssetDisplay`, `PaginatedResult<T>`, `ApiSuccess<T>`, `ApiError`

**Branded ID types**
- Added `OrgId`, `AssetId`, `UserId`, `DeptId`, `EventId`, `AssignmentId` branded types to `common.ts`
- Applied to checkout and maintenance domain function signatures — positional `(assetId, actorId)` swaps are now caught at compile time
- Boundary casts added in server actions (`assets.ts`, `maintenance.ts`) and test fixtures

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] All 278 tests pass (vitest)
- [x] Lint + prettier clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)