### PR TITLE
refactor(actions): harden asset action code

### DIFF
--- a/src/app/actions/_db.ts
+++ b/src/app/actions/_db.ts
@@ -1,0 +1,28 @@
+// Named Postgres error codes — use these instead of magic strings
+export const PG = {
+  UNIQUE_VIOLATION: '23505',
+  FOREIGN_KEY_VIOLATION: '23503',
+  NOT_NULL_VIOLATION: '23502',
+} as const
+
+/**
+ * Maps a Postgres error code to a user-friendly message.
+ * Pass `overrides` to customise messages for specific codes.
+ */
+export function mapDbError(
+  error: { code: string },
+  overrides?: Partial<Record<keyof typeof PG, string>>
+): string {
+  switch (error.code) {
+    case PG.UNIQUE_VIOLATION:
+      return overrides?.UNIQUE_VIOLATION ?? 'A duplicate value already exists.'
+    case PG.FOREIGN_KEY_VIOLATION:
+      return (
+        overrides?.FOREIGN_KEY_VIOLATION ?? 'Invalid reference — a selected value no longer exists.'
+      )
+    case PG.NOT_NULL_VIOLATION:
+      return overrides?.NOT_NULL_VIOLATION ?? 'A required field is missing.'
+    default:
+      return 'Unexpected database error'
+  }
+}

--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -25,26 +25,7 @@ import { nextTagInSequence, sanitizePrefix } from '@/lib/utils/assetTag'
 import { logAudit } from './_audit'
 import type { ActionClients } from './_context'
 import { getContext } from './_context'
-
-// Postgres error codes
-const PG = {
-  UNIQUE_VIOLATION: '23505',
-  FOREIGN_KEY_VIOLATION: '23503',
-  NOT_NULL_VIOLATION: '23502',
-} as const
-
-function mapDbError(error: { code: string }): string {
-  switch (error.code) {
-    case PG.UNIQUE_VIOLATION:
-      return 'Asset tag already exists. Use a unique tag.'
-    case PG.FOREIGN_KEY_VIOLATION:
-      return 'Invalid reference — a selected value no longer exists.'
-    case PG.NOT_NULL_VIOLATION:
-      return 'A required field is missing.'
-    default:
-      return 'Unexpected database error'
-  }
-}
+import { mapDbError } from './_db'
 
 function normalizeAssetInput(input: AssetFormInput) {
   return {
@@ -94,7 +75,10 @@ export async function createAsset(
     .select('id')
     .single()
 
-  if (error) return { error: mapDbError(error) }
+  if (error)
+    return {
+      error: mapDbError(error, { UNIQUE_VIOLATION: 'Asset tag already exists. Use a unique tag.' }),
+    }
 
   await logAudit(ctx, {
     entityType: 'asset',
@@ -164,7 +148,10 @@ export async function updateAsset(
     .eq('id', id)
     .eq('org_id', ctx.orgId)
 
-  if (error) return { error: mapDbError(error) }
+  if (error)
+    return {
+      error: mapDbError(error, { UNIQUE_VIOLATION: 'Asset tag already exists. Use a unique tag.' }),
+    }
 
   const changes: Record<string, { old: unknown; new: unknown }> = {}
   if (old.name !== normalized.name) changes.name = { old: old.name, new: normalized.name }

--- a/src/app/actions/assets.ts
+++ b/src/app/actions/assets.ts
@@ -26,6 +26,35 @@ import { logAudit } from './_audit'
 import type { ActionClients } from './_context'
 import { getContext } from './_context'
 
+// Postgres error codes
+const PG = {
+  UNIQUE_VIOLATION: '23505',
+  FOREIGN_KEY_VIOLATION: '23503',
+  NOT_NULL_VIOLATION: '23502',
+} as const
+
+function mapDbError(error: { code: string }): string {
+  switch (error.code) {
+    case PG.UNIQUE_VIOLATION:
+      return 'Asset tag already exists. Use a unique tag.'
+    case PG.FOREIGN_KEY_VIOLATION:
+      return 'Invalid reference — a selected value no longer exists.'
+    case PG.NOT_NULL_VIOLATION:
+      return 'A required field is missing.'
+    default:
+      return 'Unexpected database error'
+  }
+}
+
+function normalizeAssetInput(input: AssetFormInput) {
+  return {
+    ...input,
+    status: input.isBulk ? ('active' as const) : input.status,
+    quantity: input.isBulk ? input.quantity : null,
+    notes: input.notes?.trim() || null,
+  }
+}
+
 export async function createAsset(
   orgSlug: string,
   input: AssetFormInput,
@@ -40,33 +69,32 @@ export async function createAsset(
   const denied = createPolicy(ctx).enforce('asset:create', { departmentId: input.departmentId })
   if (denied) return denied
 
+  const normalized = normalizeAssetInput(input)
+
   const { data, error } = await ctx.admin
     .from('assets')
     .insert({
       org_id: ctx.orgId,
-      asset_tag: input.assetTag,
-      name: input.name,
-      is_bulk: input.isBulk,
-      quantity: input.isBulk ? input.quantity : null,
-      category_id: input.categoryId,
-      department_id: input.departmentId,
-      location_id: input.locationId,
-      status: input.isBulk ? 'active' : input.status,
-      purchase_date: input.purchaseDate,
-      purchase_cost: input.purchaseCost,
-      warranty_expiry: input.warrantyExpiry,
-      vendor_id: input.vendorId,
-      notes: input.notes || null,
+      asset_tag: normalized.assetTag,
+      name: normalized.name,
+      is_bulk: normalized.isBulk,
+      quantity: normalized.quantity,
+      category_id: normalized.categoryId,
+      department_id: normalized.departmentId,
+      location_id: normalized.locationId,
+      status: normalized.status,
+      purchase_date: normalized.purchaseDate,
+      purchase_cost: normalized.purchaseCost,
+      warranty_expiry: normalized.warrantyExpiry,
+      vendor_id: normalized.vendorId,
+      notes: normalized.notes,
       created_by: ctx.userId,
       updated_by: ctx.userId,
     })
     .select('id')
     .single()
 
-  if (error) {
-    if (error.code === '23505') return { error: 'Asset tag already exists. Use a unique tag.' }
-    return { error: error.message }
-  }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'asset',
@@ -93,57 +121,73 @@ export async function updateAsset(
   // Fetch old values for change tracking and permission check
   const { data: old } = await ctx.admin
     .from('assets')
-    .select('name, status, category_id, department_id, location_id, quantity')
+    .select('name, status, category_id, department_id, location_id, vendor_id, quantity')
     .eq('id', id)
     .maybeSingle()
 
-  const denied = createPolicy(ctx).enforce('asset:update', {
-    departmentId: (old?.department_id as string | null) ?? null,
+  if (!old) return { error: 'Asset not found' }
+
+  // Enforce permission on the source department
+  const deniedSource = createPolicy(ctx).enforce('asset:update', {
+    departmentId: (old.department_id as string | null) ?? null,
   })
-  if (denied) return denied
+  if (deniedSource) return deniedSource
+
+  // If moving departments, also enforce permission on the destination
+  if (input.departmentId !== (old.department_id as string | null)) {
+    const deniedDest = createPolicy(ctx).enforce('asset:update', {
+      departmentId: input.departmentId,
+    })
+    if (deniedDest) return deniedDest
+  }
+
+  const normalized = normalizeAssetInput(input)
 
   const { error } = await ctx.admin
     .from('assets')
     .update({
-      asset_tag: input.assetTag,
-      name: input.name,
-      is_bulk: input.isBulk,
-      quantity: input.isBulk ? input.quantity : null,
-      category_id: input.categoryId,
-      department_id: input.departmentId,
-      location_id: input.locationId,
-      status: input.isBulk ? 'active' : input.status,
-      purchase_date: input.purchaseDate,
-      purchase_cost: input.purchaseCost,
-      warranty_expiry: input.warrantyExpiry,
-      vendor_id: input.vendorId,
-      notes: input.notes || null,
+      asset_tag: normalized.assetTag,
+      name: normalized.name,
+      is_bulk: normalized.isBulk,
+      quantity: normalized.quantity,
+      category_id: normalized.categoryId,
+      department_id: normalized.departmentId,
+      location_id: normalized.locationId,
+      status: normalized.status,
+      purchase_date: normalized.purchaseDate,
+      purchase_cost: normalized.purchaseCost,
+      warranty_expiry: normalized.warrantyExpiry,
+      vendor_id: normalized.vendorId,
+      notes: normalized.notes,
       updated_by: ctx.userId,
     })
     .eq('id', id)
     .eq('org_id', ctx.orgId)
 
-  if (error) {
-    if (error.code === '23505') return { error: 'Asset tag already exists. Use a unique tag.' }
-    return { error: error.message }
-  }
+  if (error) return { error: mapDbError(error) }
 
-  if (old) {
-    const changes: Record<string, { old: unknown; new: unknown }> = {}
-    if (old.name !== input.name) changes.name = { old: old.name, new: input.name }
-    if (!input.isBulk && old.status !== input.status)
-      changes.status = { old: old.status, new: input.status }
-    if (input.isBulk && old.quantity !== input.quantity)
-      changes.quantity = { old: old.quantity, new: input.quantity }
+  const changes: Record<string, { old: unknown; new: unknown }> = {}
+  if (old.name !== normalized.name) changes.name = { old: old.name, new: normalized.name }
+  if (!normalized.isBulk && old.status !== normalized.status)
+    changes.status = { old: old.status, new: normalized.status }
+  if (normalized.isBulk && old.quantity !== normalized.quantity)
+    changes.quantity = { old: old.quantity, new: normalized.quantity }
+  if (old.department_id !== normalized.departmentId)
+    changes.department_id = { old: old.department_id, new: normalized.departmentId }
+  if (old.location_id !== normalized.locationId)
+    changes.location_id = { old: old.location_id, new: normalized.locationId }
+  if (old.category_id !== normalized.categoryId)
+    changes.category_id = { old: old.category_id, new: normalized.categoryId }
+  if (old.vendor_id !== normalized.vendorId)
+    changes.vendor_id = { old: old.vendor_id, new: normalized.vendorId }
 
-    await logAudit(ctx, {
-      entityType: 'asset',
-      entityId: id,
-      entityName: input.name,
-      action: 'updated',
-      changes: Object.keys(changes).length > 0 ? changes : null,
-    })
-  }
+  await logAudit(ctx, {
+    entityType: 'asset',
+    entityId: id,
+    entityName: normalized.name,
+    action: 'updated',
+    changes: Object.keys(changes).length > 0 ? changes : null,
+  })
 
   return null
 }

--- a/src/app/actions/categories.ts
+++ b/src/app/actions/categories.ts
@@ -6,6 +6,7 @@ import { CategoryFormSchema, type CategoryFormInput } from '@/lib/types'
 import { logAudit } from './_audit'
 import type { ActionClients } from './_context'
 import { getAdminCtx, getContext } from './_context'
+import { mapDbError } from './_db'
 
 export async function createCategory(
   orgSlug: string,
@@ -38,7 +39,7 @@ export async function createCategory(
     .select('id')
     .single()
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'category',
@@ -67,7 +68,7 @@ export async function updateCategory(
     .eq('id', id)
     .eq('org_id', ctx.orgId)
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'category',

--- a/src/app/actions/departments.ts
+++ b/src/app/actions/departments.ts
@@ -6,6 +6,7 @@ import { DepartmentFormSchema, type DepartmentFormInput } from '@/lib/types'
 import { logAudit } from './_audit'
 import type { ActionClients } from './_context'
 import { getAdminCtx, getContext } from './_context'
+import { mapDbError } from './_db'
 
 export async function createDepartment(
   orgSlug: string,
@@ -33,7 +34,7 @@ export async function createDepartment(
     .select('id')
     .single()
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'department',
@@ -62,7 +63,7 @@ export async function updateDepartment(
     .eq('id', id)
     .eq('org_id', ctx.orgId)
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'department',

--- a/src/app/actions/locations.ts
+++ b/src/app/actions/locations.ts
@@ -5,6 +5,7 @@ import { LocationFormSchema, type LocationFormInput } from '@/lib/types'
 
 import { logAudit } from './_audit'
 import { getAdminCtx } from './_context'
+import { mapDbError } from './_db'
 
 export async function createLocation(
   orgSlug: string,
@@ -32,7 +33,7 @@ export async function createLocation(
     .select('id')
     .single()
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'location',
@@ -61,7 +62,7 @@ export async function updateLocation(
     .eq('id', id)
     .eq('org_id', ctx.orgId)
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'location',

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -8,6 +8,7 @@ import type { CreateOrganizationInput, UpdateOrganizationInput } from '@/lib/typ
 
 import { logAudit } from './_audit'
 import { getAdminCtx, getContext } from './_context'
+import { PG, mapDbError } from './_db'
 
 export async function checkOrgAvailability(
   name: string,
@@ -50,13 +51,13 @@ export async function completeOnboardingSetup(
     .single()
 
   if (orgError) {
-    if (orgError.code === '23505') {
+    if (orgError.code === PG.UNIQUE_VIOLATION) {
       return {
         error:
           'That organization name or URL slug is already taken. Please go back and choose a different one.',
       }
     }
-    return { error: orgError.message }
+    return { error: mapDbError(orgError) }
   }
 
   const [{ error: membershipError }, { error: deptError }, { error: catError }] = await Promise.all(
@@ -103,10 +104,10 @@ export async function createOrganization(
     .single()
 
   if (orgError) {
-    if (orgError.code === '23505') {
+    if (orgError.code === PG.UNIQUE_VIOLATION) {
       return { error: 'That URL slug is already taken. Try a different one.' }
     }
-    return { error: orgError.message }
+    return { error: mapDbError(orgError) }
   }
 
   await admin.from('user_org_memberships').insert({
@@ -142,8 +143,8 @@ export async function updateOrganization(
   ])
 
   if (error) {
-    if (error.code === '23505') return { error: 'That URL slug is already taken.' }
-    return { error: error.message }
+    if (error.code === PG.UNIQUE_VIOLATION) return { error: 'That URL slug is already taken.' }
+    return { error: mapDbError(error) }
   }
 
   await logAudit(ctx, {

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -9,6 +9,7 @@ import type { UserRole } from '@/lib/types'
 import { logAudit } from './_audit'
 import type { ActionClients } from './_context'
 import { getContext } from './_context'
+import { mapDbError } from './_db'
 
 export async function updateUserRoleAction(
   orgSlug: string,
@@ -105,7 +106,7 @@ export async function revokeInviteAction(
     .eq('id', inviteId)
     .eq('org_id', ctx.orgId)
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   // Remove the pending auth user so the same email can be re-invited.
   // A pending user has a profile row but no membership row yet.
@@ -161,7 +162,7 @@ export async function removeUserAction(
     .eq('user_id', userId)
     .eq('org_id', ctx.orgId)
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await ctx.admin.auth.admin.deleteUser(userId)
 

--- a/src/app/actions/vendors.ts
+++ b/src/app/actions/vendors.ts
@@ -5,6 +5,7 @@ import { VendorFormSchema, type VendorFormInput } from '@/lib/types'
 
 import { logAudit } from './_audit'
 import { getAdminCtx } from './_context'
+import { mapDbError } from './_db'
 
 export async function createVendor(
   orgSlug: string,
@@ -31,15 +32,15 @@ export async function createVendor(
     .insert({
       org_id: ctx.orgId,
       name: input.name,
-      contact_email: input.contactEmail || null,
-      contact_phone: input.contactPhone || null,
-      website: input.website || null,
-      notes: input.notes || null,
+      contact_email: input.contactEmail?.trim() || null,
+      contact_phone: input.contactPhone?.trim() || null,
+      website: input.website?.trim() || null,
+      notes: input.notes?.trim() || null,
     })
     .select('id')
     .single()
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'vendor',
@@ -66,15 +67,15 @@ export async function updateVendor(
     .from('vendors')
     .update({
       name: input.name,
-      contact_email: input.contactEmail || null,
-      contact_phone: input.contactPhone || null,
-      website: input.website || null,
-      notes: input.notes || null,
+      contact_email: input.contactEmail?.trim() || null,
+      contact_phone: input.contactPhone?.trim() || null,
+      website: input.website?.trim() || null,
+      notes: input.notes?.trim() || null,
     })
     .eq('id', id)
     .eq('org_id', ctx.orgId)
 
-  if (error) return { error: error.message }
+  if (error) return { error: mapDbError(error) }
 
   await logAudit(ctx, {
     entityType: 'vendor',


### PR DESCRIPTION
## Summary

- **Named PG error codes** — `PG.UNIQUE_VIOLATION / FOREIGN_KEY_VIOLATION / NOT_NULL_VIOLATION` replace magic strings; `mapDbError` maps all three to human-readable messages
- **`normalizeAssetInput`** — centralises bulk/non-bulk status, quantity, and notes logic; `notes` is now trimmed before persisting
- **`updateAsset` — not-found guard** — explicit `'Asset not found'` returned when `old` is null instead of silently updating
- **`updateAsset` — dual-dept permission** — enforces `asset:update` on both the source *and* destination department when moving an asset, preventing lateral privilege escalation
- **`updateAsset` — expanded audit tracking** — `department_id`, `location_id`, `category_id`, `vendor_id` changes now recorded alongside name/status/quantity

## Test plan

- [ ] Edit an asset — audit log includes department/location/category/vendor changes
- [ ] Move asset to a department the user lacks access to — returns permission denied
- [ ] Submit asset form with a duplicate tag — error message is human-readable
- [ ] Edit a deleted/non-existent asset ID directly — returns 'Asset not found'

🤖 Generated with [Claude Code](https://claude.com/claude-code)