### PR TITLE
fix(ui): reports export, nav shadow, asset tag prefix, tab deep-links

### DIFF
--- a/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
+++ b/src/app/(app)/orgs/[slug]/assets/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, LogIn, LogOut, Pencil, Plus, Trash2 } from 'lucide-react'
 import Link from 'next/link'
-import { notFound, useParams, useRouter } from 'next/navigation'
+import { notFound, useParams, useRouter, useSearchParams } from 'next/navigation'
 import { use, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -48,9 +48,30 @@ export default function AssetDetailPage({ params }: AssetDetailPageProps) {
   const { org, role, departmentIds } = useOrg()
   const deptLabel = org?.departmentLabel ?? 'Department'
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const VALID_TABS = ['details', 'assignment', 'maintenance', 'history'] as const
+  type Tab = (typeof VALID_TABS)[number]
+  const rawTab = searchParams.get('tab') ?? 'details'
+  const activeTab: Tab = (VALID_TABS as readonly string[]).includes(rawTab)
+    ? (rawTab as Tab)
+    : 'details'
+
+  function setActiveTab(tab: string) {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('tab', tab)
+    router.replace(`?${params.toString()}`, { scroll: false })
+  }
+
   const [checkoutOpen, setCheckoutOpen] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
-  const [activeTab, setActiveTab] = useState('details')
+
+  useEffect(() => {
+    if (!searchParams.get('tab')) {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set('tab', 'details')
+      router.replace(`?${params.toString()}`, { scroll: false })
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     document.querySelector<HTMLElement>('[data-main-scroll]')?.scrollTo({ top: 0 })

--- a/src/app/(app)/orgs/[slug]/reports/page.tsx
+++ b/src/app/(app)/orgs/[slug]/reports/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Download, FileBarChart, SlidersHorizontal } from 'lucide-react'
+import { Download, FileBarChart, Loader2, SlidersHorizontal, X } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
@@ -9,7 +9,6 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { PageHeader } from '@/components/shared/PageHeader'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -18,7 +17,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -36,7 +34,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { ASSET_STATUS_CONFIG } from '@/lib/constants'
-import { type AssetFilters, useAssets } from '@/lib/hooks/useAssets'
+import { type AssetFilters, fetchAllAssetsForExport, useAssets } from '@/lib/hooks/useAssets'
 import { useCategories } from '@/lib/hooks/useCategories'
 import { useDepartments } from '@/lib/hooks/useDepartments'
 import { ASSET_STATUSES } from '@/lib/types'
@@ -51,9 +49,10 @@ type ColDef = { key: ReportColumn; label: string; allowed: boolean }
 
 export default function ReportsPage() {
   const [filters, setFilters] = useState<AssetFilters>({})
+  const [exporting, setExporting] = useState(false)
   const { data: assets, isLoading } = useAssets(filters)
   const { data: departments } = useDepartments()
-  const { org } = useOrg()
+  const { org, role, departmentIds } = useOrg()
   const deptLabel = org?.departmentLabel ?? 'Department'
   const { data: categories } = useCategories()
   const rc = org?.reportConfig ?? {}
@@ -139,10 +138,23 @@ export default function ReportsPage() {
       </div>
     )
 
-  function handleExport() {
-    exportAssetsToCsv(assets, 'asset-report.csv', visibleKeys)
-    toast.success(`Exported ${assets.length} asset${assets.length !== 1 ? 's' : ''}`)
+  async function handleExport() {
+    if (!org?.id) return
+    setExporting(true)
+    try {
+      const all = await fetchAllAssetsForExport(org.id, role ?? null, departmentIds, filters)
+      exportAssetsToCsv(all, 'asset-report.csv', visibleKeys)
+      toast.success(`Exported ${all.length} asset${all.length !== 1 ? 's' : ''}`)
+    } catch {
+      toast.error('Export failed')
+    } finally {
+      setExporting(false)
+    }
   }
+
+  const activeFilterCount = [filters.departmentId, filters.categoryId, filters.status].filter(
+    Boolean
+  ).length
 
   const visibleCols = allowedCols.filter((c) => visibleKeys.has(c.key))
   const colSpan = 2 + visibleCols.length
@@ -181,92 +193,88 @@ export default function ReportsPage() {
               </DropdownMenuContent>
             </DropdownMenu>
 
-            <Button onClick={handleExport} disabled={assets.length === 0}>
-              <Download className="mr-2 h-4 w-4" />
-              Export CSV ({assets.length})
+            <Button onClick={handleExport} disabled={exporting}>
+              {exporting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="mr-2 h-4 w-4" />
+              )}
+              {exporting ? 'Exporting…' : 'Export CSV'}
             </Button>
           </div>
         }
       />
 
       {/* Filter controls */}
-      <Card className="shadow-sm">
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-semibold">Filters</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 sm:grid-cols-3">
-            <div className="space-y-1.5">
-              <Label className="text-xs">{deptLabel}</Label>
-              <Select
-                value={filters.departmentId ?? 'all'}
-                onValueChange={(v) =>
-                  setFilters((f) => ({ ...f, departmentId: v === 'all' ? '' : v }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={`All ${deptLabel.toLowerCase()}s`} />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All {deptLabel.toLowerCase()}s</SelectItem>
-                  {departments.map((d) => (
-                    <SelectItem key={d.id} value={d.id}>
-                      {d.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <Select
+          value={filters.departmentId ?? 'all'}
+          onValueChange={(v) => setFilters((f) => ({ ...f, departmentId: v === 'all' ? '' : v }))}
+        >
+          <SelectTrigger className="h-8 w-auto min-w-[140px] text-sm">
+            <SelectValue placeholder={`All ${deptLabel.toLowerCase()}s`} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All {deptLabel.toLowerCase()}s</SelectItem>
+            {departments.map((d) => (
+              <SelectItem key={d.id} value={d.id}>
+                {d.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
-            <div className="space-y-1.5">
-              <Label className="text-xs">Category</Label>
-              <Select
-                value={filters.categoryId ?? 'all'}
-                onValueChange={(v) =>
-                  setFilters((f) => ({ ...f, categoryId: v === 'all' ? '' : v }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="All categories" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All categories</SelectItem>
-                  {categories.map((c) => (
-                    <SelectItem key={c.id} value={c.id}>
-                      {c.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+        <Select
+          value={filters.categoryId ?? 'all'}
+          onValueChange={(v) => setFilters((f) => ({ ...f, categoryId: v === 'all' ? '' : v }))}
+        >
+          <SelectTrigger className="h-8 w-auto min-w-[140px] text-sm">
+            <SelectValue placeholder="All categories" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All categories</SelectItem>
+            {categories.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
-            <div className="space-y-1.5">
-              <Label className="text-xs">Status</Label>
-              <Select
-                value={filters.status ?? 'all'}
-                onValueChange={(v) =>
-                  setFilters((f) => ({
-                    ...f,
-                    status: v === 'all' ? '' : (v as AssetFilters['status']),
-                  }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="All statuses" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All statuses</SelectItem>
-                  {ASSET_STATUSES.map((s) => (
-                    <SelectItem key={s} value={s}>
-                      {ASSET_STATUS_CONFIG[s].label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+        <Select
+          value={filters.status ?? 'all'}
+          onValueChange={(v) =>
+            setFilters((f) => ({
+              ...f,
+              status: v === 'all' ? '' : (v as AssetFilters['status']),
+            }))
+          }
+        >
+          <SelectTrigger className="h-8 w-auto min-w-[130px] text-sm">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            {ASSET_STATUSES.map((s) => (
+              <SelectItem key={s} value={s}>
+                {ASSET_STATUS_CONFIG[s].label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {activeFilterCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1.5 px-2 text-sm"
+            onClick={() => setFilters({})}
+          >
+            <X className="h-3.5 w-3.5" />
+            Clear
+          </Button>
+        )}
+      </div>
 
       {/* Preview table */}
       <div className="overflow-hidden rounded-md border shadow-sm">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -70,7 +70,7 @@ function NavLink({ item, pathname, onNavClick }: NavLinkProps) {
       className={cn(
         'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
         isActive
-          ? 'bg-sidebar-primary text-sidebar-primary-foreground shadow-sm'
+          ? 'bg-sidebar-primary text-sidebar-primary-foreground'
           : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
       )}
     >

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -29,7 +29,6 @@ export function Topbar({ onMenuClick }: TopbarProps) {
   const { resolvedTheme, setTheme } = useTheme()
   const params = useParams<{ slug?: string }>()
   const slug = params.slug ?? ''
-
   const memberships = user?.memberships ?? []
   const multipleOrgs = memberships.length > 1
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -91,4 +91,4 @@ export const WARRANTY_ALERT_DAYS = 30
 // Asset tag prefix
 // ---------------------------------------------------------------------------
 
-export const ASSET_TAG_PREFIX = 'AST'
+export const ASSET_TAG_PREFIX = 'AT'

--- a/src/lib/hooks/useAssets.ts
+++ b/src/lib/hooks/useAssets.ts
@@ -11,6 +11,7 @@ import type {
   BulkAsset,
   SerializedAsset,
   TypedAsset,
+  UserRole,
 } from '@/lib/types'
 import { ASSET_STATUS_LABELS } from '@/lib/types/asset'
 import { computeAvailable } from '@/lib/utils/availability'
@@ -329,7 +330,50 @@ export function useAsset(id: string): {
 }
 
 // ---------------------------------------------------------------------------
-// useNextAssetTag — max-based suggestion for the default "AST" prefix
+// fetchAllAssetsForExport — unpaginated fetch for CSV export
+// ---------------------------------------------------------------------------
+
+export async function fetchAllAssetsForExport(
+  orgId: string,
+  role: UserRole | null,
+  departmentIds: string[],
+  filters: AssetFilters
+): Promise<TypedAsset[]> {
+  const supabase = createClient()
+
+  let query = supabase
+    .from('assets')
+    .select(ASSET_SELECT)
+    .eq('org_id', orgId)
+    .is('deleted_at', null)
+    .is('asset_assignments.returned_at', null)
+    .order('created_at', { ascending: false })
+
+  if (filters.search) {
+    const { data: ids } = await supabase.rpc('search_asset_ids', {
+      p_org_id: orgId,
+      p_search: filters.search,
+    })
+    if (!ids || ids.length === 0) return []
+    query = query.in('id', ids as string[])
+  }
+
+  if (filters.status) query = query.eq('status', filters.status)
+  if (filters.departmentId) query = query.eq('department_id', filters.departmentId)
+  if (filters.categoryId) query = query.eq('category_id', filters.categoryId)
+
+  query = applyDepartmentConstraint(
+    query,
+    createPolicy({ role: role ?? 'viewer', departmentIds }).queryConstraint()
+  )
+
+  const { data: rows, error } = await query
+  if (error || !rows) return []
+  return (rows as unknown as AssetRow[]).map(mapAssetRow)
+}
+
+// ---------------------------------------------------------------------------
+// useNextAssetTag — max-based suggestion for the default "AT" prefix
 // ---------------------------------------------------------------------------
 
 export function useNextAssetTag(): string {


### PR DESCRIPTION
## Summary

- **Reports export**: `fetchAllAssetsForExport` bypasses pagination so all matching assets are exported (previously capped at 25); filter bar replaced with compact inline selects + Clear button; export button shows spinner during fetch
- **Sidebar shadow**: removed `shadow-sm` from active nav link which caused a rectangular drop shadow outside the rounded corners
- **Asset tag prefix**: changed `ASSET_TAG_PREFIX` from `'AST'` → `'AT'` to match seed data
- **Asset tab deep-links**: active tab syncs to `?tab=` URL param (`details` | `assignment` | `maintenance` | `history`); initializes to `?tab=details` on first load so tabs are always linkable

## Test plan

- [ ] Reports: apply filters, click Export CSV — verify all assets (not just 25) are downloaded
- [ ] Reports: verify compact filter bar renders correctly, Clear button appears when filters active
- [ ] Sidebar: verify active nav item has no rectangular shadow artifact
- [ ] Create new asset — verify default tag prefix is `AT-XXXX`
- [ ] Asset detail: click an asset, verify URL shows `?tab=details`
- [ ] Switch tabs, verify URL updates accordingly
- [ ] Copy URL with `?tab=history`, open in new tab — verify History tab is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)