### PR TITLE
chore: failing test and deprecated code used

### DIFF
--- a/src/components/assets/AssetForm.tsx
+++ b/src/components/assets/AssetForm.tsx
@@ -34,7 +34,7 @@ import { useDepartmentMutations, useDepartments } from '@/lib/hooks/useDepartmen
 import { useLocationMutations, useLocations } from '@/lib/hooks/useLocations'
 import { useVendorMutations, useVendors } from '@/lib/hooks/useVendors'
 import { ASSET_STATUSES, AssetFormSchema, type AssetFormInput } from '@/lib/types'
-import type { AssetWithRelations } from '@/lib/types'
+import type { TypedAsset } from '@/lib/types'
 import { parseTagParts } from '@/lib/utils/assetTag'
 import { useOrg } from '@/providers/OrgProvider'
 
@@ -47,7 +47,7 @@ import { useOrg } from '@/providers/OrgProvider'
 // ---------------------------------------------------------------------------
 
 interface AssetFormProps {
-  asset?: AssetWithRelations
+  asset?: TypedAsset
   defaultAssetTag?: string
 }
 

--- a/src/lib/utils/__tests__/formatters.test.ts
+++ b/src/lib/utils/__tests__/formatters.test.ts
@@ -167,6 +167,10 @@ describe('formatCompactCurrency', () => {
   })
 
   it('formats millions as $M', () => {
+    expect(formatCompactCurrency(1700000)).toBe('$1.7M')
+  })
+
+  it('truncates trailing dot zero (.0)', () => {
     expect(formatCompactCurrency(1000000)).toBe('$1M')
   })
 })

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -54,7 +54,9 @@ export function formatCompactCurrency(value: number): string {
     currency: 'USD',
     notation: 'compact',
     maximumFractionDigits: 1,
-  }).format(value)
+  })
+    .format(value)
+    .replace(/.0/g, '')
 }
 
 /** Get user initials for avatar fallback */

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -53,10 +53,9 @@ export function formatCompactCurrency(value: number): string {
     style: 'currency',
     currency: 'USD',
     notation: 'compact',
+    minimumFractionDigits: 0,
     maximumFractionDigits: 1,
-  })
-    .format(value)
-    .replace(/.0/g, '')
+  }).format(value)
 }
 
 /** Get user initials for avatar fallback */


### PR DESCRIPTION
- The test `formatCompactCurrency` has an edge case where an amount like 1,000 will be formatted as `$1.0K` instead of `$1K`. I didn't see a better way to go about fixing this, so I used a regex to `replace` the first instance of `.0`.
- `AssetWithRelation` is deprecated, but still used in `@/components/assets/AssetForm.tsx`.